### PR TITLE
Add three-page marketing site for BlueWave Print Studio

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact BlueWave Print Studio | Local Print Experts</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="logo" href="/">BlueWave Print Studio</a>
+        <nav>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a class="active" href="contact.html">Contact &amp; About</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <span class="badge">We answer within one business hour</span>
+            <h1>Let’s bring your next print idea to life</h1>
+            <p>
+              Reach out for project estimates, design consultations, or a quick proof review. Our in-house specialists are ready to support every step, from concept through delivery.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="grid" style="max-width: 960px">
+          <div class="contact-card">
+            <strong>Visit the studio</strong>
+            <div>
+              1432 Shoreline Blvd<br />
+              Corpus Christi, TX 78401
+            </div>
+            <div>
+              <strong>Hours</strong>
+              <div>Monday – Friday: 8:30a – 6:00p</div>
+              <div>Saturday: By appointment</div>
+            </div>
+            <div>
+              <strong>Call or text</strong>
+              <a href="tel:13615550198">(361) 555-0198</a>
+            </div>
+            <div>
+              <strong>Email</strong>
+              <a href="mailto:hello@bluewaveprint.com">hello@bluewaveprint.com</a>
+            </div>
+          </div>
+
+          <div class="contact-card">
+            <strong>Start a project</strong>
+            <form class="contact-form">
+              <label>
+                Name
+                <input type="text" name="name" placeholder="Jordan Smith" />
+              </label>
+              <label>
+                Company
+                <input type="text" name="company" placeholder="Harbor City Outfitters" />
+              </label>
+              <label>
+                Email
+                <input type="email" name="email" placeholder="you@example.com" />
+              </label>
+              <label>
+                Project details
+                <textarea name="details" placeholder="Tell us about quantities, sizes, deadlines, and finishing needs."></textarea>
+              </label>
+              <button class="primary-button" type="submit">Request quote →</button>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section class="section alt">
+        <div class="grid" style="max-width: 900px">
+          <h2>About BlueWave Print Studio</h2>
+          <p>
+            Founded in 1998 by lifelong Corpus Christi residents Ana and Mateo Castillo, BlueWave Print Studio started as a small-format print shop helping neighborhood schools and non-profits. Today, our 12-person team pairs design-forward thinking with state-of-the-art production technology to deliver consistent, color-accurate results for businesses across South Texas.
+          </p>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Community roots</h3>
+              <p>We reinvest 5% of annual profits into local art programs, youth sports, and beach cleanups.</p>
+            </article>
+            <article class="card">
+              <h3>Certified sustainability</h3>
+              <p>BlueWave is FSC®-certified and offers recycled, post-consumer paper stocks for every product line.</p>
+            </article>
+            <article class="card">
+              <h3>Partners in growth</h3>
+              <p>From branding refreshes to multi-location signage rollouts, we serve as a dedicated print partner for 200+ area businesses.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-content">
+        <div>
+          <div class="footer-logo">BlueWave Print Studio</div>
+          <p>Modern print craftsmanship from a locally owned team serving the Coastal Bend for over 25 years.</p>
+        </div>
+        <div>
+          <strong>Visit</strong>
+          <ul class="list-reset">
+            <li>1432 Shoreline Blvd</li>
+            <li>Corpus Christi, TX 78401</li>
+            <li>Mon–Fri: 8:30a – 6:00p</li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul class="list-reset">
+            <li>(361) 555-0198</li>
+            <li><a href="mailto:hello@bluewaveprint.com">hello@bluewaveprint.com</a></li>
+            <li><a href="contact.html">Start a project →</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">© <span id="year"></span> BlueWave Print Studio. All rights reserved.</div>
+    </footer>
+
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BlueWave Print Studio | Local Print Experts</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="logo" href="/">BlueWave Print Studio</a>
+        <nav>
+          <ul>
+            <li><a class="active" href="index.html">Home</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="contact.html">Contact &amp; About</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <span class="badge">Locally owned • Est. 1998</span>
+            <h1>Modern printing crafted for businesses that move fast</h1>
+            <p>
+              BlueWave Print Studio delivers vibrant marketing materials, custom packaging, and signage with turnaround times tailored for growing businesses in the Coastal Bend.
+            </p>
+            <a class="primary-button" href="services.html">Explore Services →</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section alt">
+        <div class="grid">
+          <h2>What we print every day</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Premium Marketing Collateral</h3>
+              <p>
+                Brochures, business cards, presentation folders, and mailers that match your brand colors with edge-to-edge precision.
+              </p>
+              <ul class="checklist">
+                <li>Next-day rush available</li>
+                <li>Soft-touch and matte finishes</li>
+                <li>Design assistance included</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Large Format Signage</h3>
+              <p>
+                Banners, trade show displays, and window graphics engineered to stand up to Gulf Coast weather and sunlight.
+              </p>
+              <ul class="checklist">
+                <li>UV-resistant inks</li>
+                <li>Indoor &amp; outdoor mounting options</li>
+                <li>Installation support</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Custom Packaging &amp; Labels</h3>
+              <p>
+                Short-run packaging, labels, and stickers that keep small-batch products looking professional and shelf-ready.
+              </p>
+              <ul class="checklist">
+                <li>Low minimum quantities</li>
+                <li>Eco-friendly substrates</li>
+                <li>Variable data personalization</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="grid">
+          <h2>Why Coastal businesses choose BlueWave</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Real humans, rapid answers</h3>
+              <p>
+                Call or text our production team directly. Receive proofs, updates, and timelines without waiting in a ticket queue.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Technology built for speed</h3>
+              <p>
+                We invest in digital presses and wide-format printers that keep projects moving—most orders are fulfilled within 48 hours.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Delivery that saves you time</h3>
+              <p>
+                Complimentary delivery within 20 miles of Corpus Christi and coordinated shipping for statewide accounts.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section alt">
+        <div class="grid">
+          <h2>Client stories</h2>
+          <div class="grid grid-3">
+            <article class="card testimonial">
+              <p>
+                “BlueWave transformed our event experience. They produced a full suite of signage and handouts in under three days, and the color accuracy was perfect.”
+              </p>
+              <cite>— Maya Flores, Harbor City Chamber</cite>
+            </article>
+            <article class="card testimonial">
+              <p>
+                “Our product packaging looks like a national brand now. Their team sourced sustainable materials and delivered an unboxing experience customers rave about.”
+              </p>
+              <cite>— Ruben Ortiz, Gulf Harvest Coffee</cite>
+            </article>
+            <article class="card testimonial">
+              <p>
+                “From first draft to final print, BlueWave communicates clearly. Their delivery service means we never have to leave the shop to get materials.”
+              </p>
+              <cite>— Leah Thompson, Seabreeze Florals</cite>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-content">
+        <div>
+          <div class="footer-logo">BlueWave Print Studio</div>
+          <p>Modern print craftsmanship from a locally owned team serving the Coastal Bend for over 25 years.</p>
+        </div>
+        <div>
+          <strong>Visit</strong>
+          <ul class="list-reset">
+            <li>1432 Shoreline Blvd</li>
+            <li>Corpus Christi, TX 78401</li>
+            <li>Mon–Fri: 8:30a – 6:00p</li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul class="list-reset">
+            <li>(361) 555-0198</li>
+            <li><a href="mailto:hello@bluewaveprint.com">hello@bluewaveprint.com</a></li>
+            <li><a href="contact.html">Start a project →</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">© <span id="year"></span> BlueWave Print Studio. All rights reserved.</div>
+    </footer>
+
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Print Services | BlueWave Print Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="logo" href="/">BlueWave Print Studio</a>
+        <nav>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a class="active" href="services.html">Services</a></li>
+            <li><a href="contact.html">Contact &amp; About</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div class="service-hero">
+            <span class="badge">Fast timelines • Expert finishing</span>
+            <h1>Services engineered to make your brand look its best</h1>
+            <p>
+              From single-run brochures to multi-location campaigns, BlueWave offers full-service printing, finishing, and delivery tailored to small and mid-sized businesses.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section alt">
+        <div class="grid">
+          <h2>Core print capabilities</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Digital &amp; Offset Printing</h3>
+              <p>Ultra-crisp color reproduction for marketing collateral, booklets, and stationery with turnaround as fast as 24 hours.</p>
+              <ul class="checklist">
+                <li>Full bleed and specialty finishes</li>
+                <li>Mailing and fulfillment support</li>
+                <li>Variable data personalization</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Wide Format &amp; Signage</h3>
+              <p>Durable banners, wall murals, floor graphics, and trade show booths produced with weather-resistant inks and lamination.</p>
+              <ul class="checklist">
+                <li>On-site surveys &amp; installation</li>
+                <li>Fabric, vinyl, and mesh materials</li>
+                <li>Backlit and dimensional signage</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Packaging &amp; Labels</h3>
+              <p>Custom dielines, short-run folding cartons, and pressure-sensitive labels that highlight artisanal and specialty products.</p>
+              <ul class="checklist">
+                <li>Eco-friendly and textured stocks</li>
+                <li>Low minimum orders</li>
+                <li>Shrink sleeves &amp; tamper seals</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="grid">
+          <h2>Popular service bundles</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>Launch Kit</h3>
+              <div class="price">$685</div>
+              <p>Everything a new business needs to look polished at first impression.</p>
+              <ul class="checklist">
+                <li>500 business cards with soft-touch finish</li>
+                <li>250 tri-fold brochures</li>
+                <li>Storefront vinyl banner and window decal</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Event Spotlight</h3>
+              <div class="price">$1,140</div>
+              <p>Turn heads at expos, conferences, and local festivals with cohesive visuals.</p>
+              <ul class="checklist">
+                <li>10 ft. tension fabric display</li>
+                <li>Two retractable banners</li>
+                <li>500 full-color postcards</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Retail Refresh</h3>
+              <div class="price">$1,980</div>
+              <p>Seasonal signage and packaging updates to keep your shelves fresh and on-brand.</p>
+              <ul class="checklist">
+                <li>Custom shelf talkers &amp; wobblers</li>
+                <li>1,000 product labels with spot UV</li>
+                <li>Exterior storefront signage update</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section alt">
+        <div class="grid" style="max-width: 980px">
+          <h2>How we deliver every project</h2>
+          <div class="grid grid-3">
+            <article class="card">
+              <h3>1. Discover &amp; scope</h3>
+              <p>We review your brand assets, specs, and timeline to recommend materials that balance impact and budget.</p>
+            </article>
+            <article class="card">
+              <h3>2. Proof &amp; produce</h3>
+              <p>Receive digital or physical proofs within 24 hours. After approval, our production team manages print and finishing in-house.</p>
+            </article>
+            <article class="card">
+              <h3>3. Deliver &amp; support</h3>
+              <p>Complimentary local delivery, optional installation, and reorder reminders keep your marketing running smoothly.</p>
+            </article>
+          </div>
+          <div class="card" style="margin-top: 2rem; text-align: center">
+            <h3>Need something unique?</h3>
+            <p>Our team can source specialty substrates, manage warehousing, or build custom storefronts for franchise networks.</p>
+            <a class="primary-button" href="contact.html">Talk with a specialist →</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-content">
+        <div>
+          <div class="footer-logo">BlueWave Print Studio</div>
+          <p>Modern print craftsmanship from a locally owned team serving the Coastal Bend for over 25 years.</p>
+        </div>
+        <div>
+          <strong>Visit</strong>
+          <ul class="list-reset">
+            <li>1432 Shoreline Blvd</li>
+            <li>Corpus Christi, TX 78401</li>
+            <li>Mon–Fri: 8:30a – 6:00p</li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul class="list-reset">
+            <li>(361) 555-0198</li>
+            <li><a href="mailto:hello@bluewaveprint.com">hello@bluewaveprint.com</a></li>
+            <li><a href="contact.html">Start a project →</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">© <span id="year"></span> BlueWave Print Studio. All rights reserved.</div>
+    </footer>
+
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,308 @@
+:root {
+  --primary: #1d4ed8;
+  --primary-dark: #1e40af;
+  --accent: #f59e0b;
+  --bg: #f8fafc;
+  --text: #1f2937;
+  --muted: #64748b;
+  --white: #ffffff;
+  --max-width: 1100px;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+header {
+  background: var(--white);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.navbar {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--primary);
+  letter-spacing: 0.03em;
+}
+
+nav ul {
+  display: flex;
+  list-style: none;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  font-weight: 500;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+nav a.active,
+nav a:hover {
+  background: rgba(29, 78, 216, 0.1);
+}
+
+.hero {
+  background: linear-gradient(140deg, rgba(29, 78, 216, 0.12), rgba(59, 130, 246, 0.05));
+  padding: 6rem 1.5rem 5rem;
+}
+
+.hero-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 3rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  margin-bottom: 1rem;
+  color: var(--primary-dark);
+}
+
+.hero p {
+  font-size: 1.1rem;
+  color: var(--muted);
+  max-width: 600px;
+}
+
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  background: var(--primary);
+  color: var(--white);
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px -15px rgba(29, 78, 216, 0.75);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px -20px rgba(29, 78, 216, 0.9);
+}
+
+.section {
+  padding: 4rem 1.5rem;
+}
+
+.section.alt {
+  background: var(--white);
+}
+
+.section h2 {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  text-align: center;
+  color: var(--primary-dark);
+}
+
+.grid {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.grid-3 {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--white);
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 45px -26px rgba(15, 23, 42, 0.45);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.35rem 0.75rem;
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--accent);
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.testimonial {
+  position: relative;
+  padding-top: 1rem;
+}
+
+.testimonial::before {
+  content: '“';
+  position: absolute;
+  top: -40px;
+  left: -10px;
+  font-size: 5rem;
+  color: rgba(29, 78, 216, 0.15);
+}
+
+.testimonial cite {
+  display: block;
+  margin-top: 1.5rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+footer {
+  background: #0f172a;
+  color: rgba(226, 232, 240, 0.9);
+  padding: 3rem 1.5rem 2rem;
+}
+
+.footer-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.footer-logo {
+  font-weight: 700;
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.footer-bottom {
+  margin-top: 2rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.list-reset {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact-card {
+  background: var(--white);
+  border-radius: 20px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 50px -35px rgba(15, 23, 42, 0.4);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.contact-card strong {
+  display: block;
+  font-size: 1rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.contact-form label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(100, 116, 139, 0.25);
+  font: inherit;
+  resize: vertical;
+  min-height: 52px;
+}
+
+.contact-form textarea {
+  min-height: 140px;
+}
+
+.contact-form button {
+  justify-self: start;
+}
+
+.service-hero {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 3rem;
+}
+
+.price {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+ul.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+ul.checklist li::before {
+  content: '✔';
+  color: var(--primary);
+  margin-right: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .navbar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  nav ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- create a modern three-page marketing site for BlueWave Print Studio with home, services, and contact/about pages
- implement shared styling, responsive layout, and reusable components across the static pages
- populate pages with mock company data, service offerings, and testimonials tailored to a local print studio

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc1c4c636083339d0ad87982bf0807