### PR TITLE
Store site content in SQLite database

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,14 +1,14 @@
 # Code Review Suggestions
 
 ## 1. Harden admin authentication
-* Hash the admin password instead of storing it as plaintext in the `settings` table, and require the default to be rotated on first login. The current implementation reads and writes the password value directly, so anyone with database access can recover it and the default remains active indefinitely.【F:app.py†L37-L97】
-* Consider refusing to start the app if `SECRET_KEY` is left at the default so session cookies remain protected in production deployments.【F:app.py†L25-L30】
+* Hash the admin password instead of storing it as plaintext in the `settings` table, and require the default to be rotated on first login. The current implementation reads and writes the password value directly, so anyone with database access can recover it and the default remains active indefinitely.【F:app.py†L88-L109】
+* Consider refusing to start the app if `SECRET_KEY` is left at the default so session cookies remain protected in production deployments.【F:app.py†L28-L33】
 
 ## 2. Tighten upload handling
-* The media upload path accepts any file type and saves it verbatim. Introduce an allow-list of MIME types/extensions, enforce size limits, and store files under generated names to avoid collisions or executable uploads that could be served back to users.【F:app.py†L187-L199】
+* The media upload path accepts any file type and saves it verbatim. Introduce an allow-list of MIME types/extensions, enforce size limits, and store files under generated names to avoid collisions or executable uploads that could be served back to users.【F:app.py†L524-L533】
 
-## 3. Add safer content editing workflow
-* `update_content_from_form` persists edits immediately to the live content row in the database, so a typo instantly affects the public site. Providing a draft/preview mode or version history would let admins review changes, roll back mistakes, and collaborate more safely.【F:app.py†L118-L128】【F:app.py†L281-L360】
+## 3. Expand draft safety controls
+* Admin mode now persists unsaved edits in a shared `drafts` table keyed only by the session cookie. Consider adding automatic cleanup for abandoned drafts, per-user identifiers, or change history so concurrent editors don't overwrite each other and operators can revert to prior revisions if a draft is accidentally saved.【F:app.py†L152-L213】【F:app.py†L560-L590】
 
 ## 4. Improve mobile experience controls
-* `should_use_mobile_alt` relies solely on User-Agent sniffing and cannot be overridden once detected. Consider a persistent user preference (cookie or query param) so users can opt out of the mobile template, and expand detection to cover modern tablet UAs more accurately.【F:app.py†L332-L361】
+* `should_use_mobile_alt` relies solely on User-Agent sniffing and cannot be overridden once detected. Consider a persistent user preference (cookie or query param) so users can opt out of the mobile template, and expand detection to cover modern tablet UAs more accurately.【F:app.py†L614-L629】

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,14 @@
+# Code Review Suggestions
+
+## 1. Harden admin authentication
+* Hash the admin password instead of storing it as plaintext in the `settings` table, and require the default to be rotated on first login. The current implementation reads and writes the password value directly, so anyone with database access can recover it and the default remains active indefinitely.【F:app.py†L37-L97】
+* Consider refusing to start the app if `SECRET_KEY` is left at the default so session cookies remain protected in production deployments.【F:app.py†L25-L30】
+
+## 2. Tighten upload handling
+* The media upload path accepts any file type and saves it verbatim. Introduce an allow-list of MIME types/extensions, enforce size limits, and store files under generated names to avoid collisions or executable uploads that could be served back to users.【F:app.py†L187-L199】
+
+## 3. Add safer content editing workflow
+* `update_content_from_form` persists edits immediately to the live content row in the database, so a typo instantly affects the public site. Providing a draft/preview mode or version history would let admins review changes, roll back mistakes, and collaborate more safely.【F:app.py†L118-L128】【F:app.py†L281-L360】
+
+## 4. Improve mobile experience controls
+* `should_use_mobile_alt` relies solely on User-Agent sniffing and cannot be overridden once detected. Consider a persistent user preference (cookie or query param) so users can opt out of the mobile template, and expand detection to cover modern tablet UAs more accurately.【F:app.py†L332-L361】

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>=3.0,<4.0
+SQLAlchemy>=2.0,<3.0

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -25,6 +25,226 @@ body.admin-border {
   box-shadow: inset 0 0 0 6px #dc2626;
 }
 
+body.admin-mode-active {
+  padding-top: 3.5rem;
+}
+
+.admin-toolbar {
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 20px 55px -35px rgba(220, 38, 38, 0.75);
+  border: 1px solid rgba(220, 38, 38, 0.4);
+  z-index: 120;
+  backdrop-filter: blur(6px);
+}
+
+.admin-toolbar__label {
+  font-weight: 600;
+  color: #b91c1c;
+  letter-spacing: 0.01em;
+}
+
+.admin-toolbar__link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.admin-toolbar__button {
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.admin-toolbar__button:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.admin-toolbar__button--primary {
+  background: var(--primary);
+  color: #ffffff;
+  box-shadow: 0 14px 35px -20px rgba(37, 99, 235, 0.75);
+}
+
+.admin-toolbar__button--ghost {
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--primary-dark);
+  border: 1px solid rgba(37, 99, 235, 0.35);
+}
+
+.page-editor {
+  position: fixed;
+  top: 4.5rem;
+  right: 1.25rem;
+  width: min(380px, 92vw);
+  max-height: calc(100vh - 6rem);
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 35px 80px -45px rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.25rem;
+  display: none;
+  z-index: 110;
+  overflow: hidden;
+}
+
+.page-editor.is-open {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 1rem;
+}
+
+.page-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.page-editor__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.page-editor__toggle {
+  border: none;
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.page-editor__body {
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.form-fields {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.form-fields label {
+  display: grid;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.form-fields input,
+.form-fields textarea,
+.form-fields select {
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(100, 116, 139, 0.28);
+  font: inherit;
+  background: #ffffff;
+  resize: vertical;
+}
+
+.form-fields textarea {
+  min-height: 90px;
+}
+
+.field-help {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.collection-wrapper {
+  border: 2px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(241, 245, 249, 0.55);
+}
+
+.collection {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.collection-item {
+  border: 1px solid rgba(100, 116, 139, 0.25);
+  border-radius: 14px;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.6rem;
+  background: #ffffff;
+}
+
+.collection-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  gap: 0.5rem;
+}
+
+.collection-item button.remove-item {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.add-item {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid rgba(37, 99, 235, 0.45);
+  border-radius: 999px;
+  padding: 0.3rem 0.9rem 0.3rem 0.55rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.add-item::before {
+  content: '+';
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+
+.editor-hint {
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: rgba(226, 232, 240, 0.4);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -21,6 +21,10 @@ body {
   line-height: 1.6;
 }
 
+body.admin-border {
+  box-shadow: inset 0 0 0 6px #dc2626;
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/static/js/admin-mode.js
+++ b/static/js/admin-mode.js
@@ -1,0 +1,349 @@
+(function () {
+  const body = document.body;
+  if (!body || body.dataset.adminMode !== '1') {
+    return;
+  }
+
+  const pageKey = body.dataset.pageKey;
+  const editor = document.querySelector('.page-editor[data-page-editor]');
+  const form = editor ? editor.querySelector('[data-editor-form]') : null;
+
+  if (!pageKey || !editor || !form) {
+    return;
+  }
+
+  const debounce = (fn, delay = 250) => {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), delay);
+    };
+  };
+
+  const renderers = {
+    home: renderHome,
+    services: renderServices,
+    contact: renderContact,
+  };
+
+  const render = renderers[pageKey];
+  if (!render) {
+    return;
+  }
+
+  const toggleButton = editor.querySelector('[data-editor-toggle]');
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      const isOpen = editor.classList.toggle('is-open');
+      toggleButton.textContent = isOpen ? 'Hide editor' : 'Show editor';
+    });
+  }
+
+  enhanceCollections(form);
+
+  const submitDraft = debounce(() => {
+    const formData = new FormData(form);
+    fetch(`/admin/draft/${pageKey}` , {
+      method: 'POST',
+      body: formData,
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (!data || data.error) {
+          console.error(data ? data.error : 'Unknown error updating draft');
+          return;
+        }
+        render(data.page || {}, data.site || {});
+      })
+      .catch((error) => {
+        console.error('Error updating draft', error);
+      });
+  }, 250);
+
+  form.addEventListener('input', submitDraft);
+  form.addEventListener('change', submitDraft);
+  form.addEventListener('submit', (event) => event.preventDefault());
+
+  function enhanceCollections(scope) {
+    scope.querySelectorAll('.add-item').forEach((button) => {
+      button.addEventListener('click', () => {
+        const templateId = button.dataset.template;
+        const template = templateId ? document.getElementById(templateId) : null;
+        if (!template || !template.content.firstElementChild) {
+          return;
+        }
+        const clone = template.content.firstElementChild.cloneNode(true);
+        const collection = button.closest('.collection-wrapper')?.querySelector('.collection');
+        if (!collection) {
+          return;
+        }
+        collection.appendChild(clone);
+        attachRemoveHandlers(clone);
+        submitDraft();
+      });
+    });
+
+    attachRemoveHandlers(scope);
+  }
+
+  function attachRemoveHandlers(scope) {
+    scope.querySelectorAll('.remove-item').forEach((button) => {
+      if (button.dataset.bound === '1') {
+        return;
+      }
+      button.dataset.bound = '1';
+      button.addEventListener('click', () => {
+        const item = button.closest('.collection-item');
+        item?.remove();
+        submitDraft();
+      });
+    });
+  }
+
+  function setText(selector, value) {
+    const element = document.querySelector(selector);
+    if (!element) {
+      return;
+    }
+    element.textContent = value || '';
+  }
+
+  function setLink(selector, text, href) {
+    const element = document.querySelector(selector);
+    if (!element) {
+      return;
+    }
+    element.textContent = text || '';
+    if (href) {
+      element.setAttribute('href', href);
+    } else {
+      element.removeAttribute('href');
+    }
+  }
+
+  function renderImage(container, src, alt) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    if (src) {
+      container.hidden = false;
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = alt || '';
+      img.loading = 'lazy';
+      container.appendChild(img);
+    } else {
+      container.hidden = true;
+    }
+  }
+
+  function renderList(containerSelector, templateId, items, configure) {
+    const container = typeof containerSelector === 'string'
+      ? document.querySelector(containerSelector)
+      : containerSelector;
+    const template = templateId ? document.getElementById(templateId) : null;
+    if (!container || !template || !template.content.firstElementChild) {
+      return;
+    }
+    container.innerHTML = '';
+    (items || []).forEach((item) => {
+      const node = template.content.firstElementChild.cloneNode(true);
+      configure(node, item);
+      container.appendChild(node);
+    });
+  }
+
+  function renderHome(page) {
+    const hero = page.hero || {};
+    setText('[data-slot="home.hero.badge"]', hero.badge);
+    setText('[data-slot="home.hero.title"]', hero.title);
+    setText('[data-slot="home.hero.description"]', hero.description);
+    setLink('[data-slot-link="home.hero.cta"]', hero.cta_text, hero.cta_link || '#');
+    renderImage(document.querySelector('[data-slot-container="home.hero.image"]'), hero.image, hero.image_alt);
+
+    const whatWePrint = page.what_we_print || {};
+    setText('[data-slot="home.what_we_print.title"]', whatWePrint.title);
+    renderList('[data-repeat="home.what_we_print.items"]', 'tpl-home-what-we-print', whatWePrint.items || [], (node, item) => {
+      const cardImage = node.querySelector('[data-image-container]');
+      renderImage(cardImage, item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+      const list = node.querySelector('[data-list]');
+      if (list) {
+        list.innerHTML = '';
+        if (item.bullets && item.bullets.length) {
+          list.hidden = false;
+          item.bullets.forEach((bullet) => {
+            const li = document.createElement('li');
+            li.textContent = bullet;
+            list.appendChild(li);
+          });
+        } else {
+          list.hidden = true;
+        }
+      }
+    });
+
+    const whyChoose = page.why_choose || {};
+    setText('[data-slot="home.why_choose.title"]', whyChoose.title);
+    renderList('[data-repeat="home.why_choose.items"]', 'tpl-home-why-choose', whyChoose.items || [], (node, item) => {
+      const cardImage = node.querySelector('[data-image-container]');
+      renderImage(cardImage, item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+    });
+
+    const testimonials = page.testimonials || {};
+    setText('[data-slot="home.testimonials.title"]', testimonials.title);
+    renderList('[data-repeat="home.testimonials.items"]', 'tpl-home-testimonial', testimonials.items || [], (node, item) => {
+      const quote = node.querySelector('p');
+      const cite = node.querySelector('cite');
+      if (quote) quote.textContent = item.quote || '';
+      if (cite) cite.textContent = item.author || '';
+    });
+  }
+
+  function renderServices(page) {
+    const hero = page.hero || {};
+    setText('[data-slot="services.hero.badge"]', hero.badge);
+    setText('[data-slot="services.hero.title"]', hero.title);
+    setText('[data-slot="services.hero.description"]', hero.description);
+
+    const capabilities = page.capabilities || {};
+    setText('[data-slot="services.capabilities.title"]', capabilities.title);
+    renderList('[data-repeat="services.capabilities.items"]', 'tpl-services-capability', capabilities.items || [], (node, item) => {
+      renderImage(node.querySelector('[data-image-container]'), item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+      const list = node.querySelector('[data-list]');
+      if (list) {
+        list.innerHTML = '';
+        if (item.bullets && item.bullets.length) {
+          list.hidden = false;
+          item.bullets.forEach((bullet) => {
+            const li = document.createElement('li');
+            li.textContent = bullet;
+            list.appendChild(li);
+          });
+        } else {
+          list.hidden = true;
+        }
+      }
+    });
+
+    const bundles = page.bundles || {};
+    setText('[data-slot="services.bundles.title"]', bundles.title);
+    renderList('[data-repeat="services.bundles.items"]', 'tpl-services-bundle', bundles.items || [], (node, item) => {
+      renderImage(node.querySelector('[data-image-container]'), item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const price = node.querySelector('.price');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (price) price.textContent = item.price || '';
+      if (description) description.textContent = item.description || '';
+      const list = node.querySelector('[data-list]');
+      if (list) {
+        list.innerHTML = '';
+        if (item.bullets && item.bullets.length) {
+          list.hidden = false;
+          item.bullets.forEach((bullet) => {
+            const li = document.createElement('li');
+            li.textContent = bullet;
+            list.appendChild(li);
+          });
+        } else {
+          list.hidden = true;
+        }
+      }
+    });
+
+    const process = page.process || {};
+    setText('[data-slot="services.process.title"]', process.title);
+    renderList('[data-repeat="services.process.steps"]', 'tpl-services-step', process.steps || [], (node, item) => {
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+    });
+    const cta = process.cta || {};
+    setText('[data-slot="services.process.cta.title"]', cta.title);
+    setText('[data-slot="services.process.cta.description"]', cta.description);
+    setLink('[data-slot-link="services.process.cta"]', cta.text, cta.link || '#');
+  }
+
+  function renderContact(page) {
+    const hero = page.hero || {};
+    setText('[data-slot="contact.hero.badge"]', hero.badge);
+    setText('[data-slot="contact.hero.title"]', hero.title);
+    setText('[data-slot="contact.hero.description"]', hero.description);
+
+    const studio = page.studio || {};
+    setText('[data-slot="contact.studio.visit_title"]', studio.visit_title);
+    renderSimpleList('[data-list="contact.studio.address"]', studio.address || []);
+    setText('[data-slot="contact.studio.hours_title"]', studio.hours_title);
+    renderSimpleList('[data-list="contact.studio.hours"]', studio.hours || []);
+    setLink('[data-slot-link="contact.studio.phone"]', studio.phone, studio.phone_href ? `tel:${studio.phone_href}` : '');
+    setLink('[data-slot-link="contact.studio.email"]', studio.email, studio.email ? `mailto:${studio.email}` : '');
+    setText('[data-slot="contact.studio.phone_title"]', studio.phone_title);
+    setText('[data-slot="contact.studio.email_title"]', studio.email_title);
+
+    const formData = page.form || {};
+    setText('[data-slot="contact.form.title"]', formData.title);
+    const formContainer = document.querySelector('[data-repeat="contact.form.fields"]');
+    const formTemplate = document.getElementById('tpl-contact-form-field');
+    if (formContainer && formTemplate && formTemplate.content.firstElementChild) {
+      formContainer.innerHTML = '';
+      (formData.fields || []).forEach((field) => {
+        const node = formTemplate.content.firstElementChild.cloneNode(true);
+        const label = node.querySelector('.field-label');
+        const input = node.querySelector('input, textarea');
+        if (label) label.textContent = field.label || '';
+        if (input) {
+          if (field.type === 'textarea') {
+            const textarea = document.createElement('textarea');
+            textarea.placeholder = field.placeholder || '';
+            textarea.name = field.name || '';
+            node.replaceChild(textarea, input);
+          } else {
+            input.type = field.type || 'text';
+            input.placeholder = field.placeholder || '';
+            input.name = field.name || '';
+          }
+        }
+        formContainer.appendChild(node);
+      });
+    }
+    setText('[data-slot="contact.form.submit_text"]', formData.submit_text);
+
+    const about = page.about || {};
+    setText('[data-slot="contact.about.title"]', about.title);
+    setText('[data-slot="contact.about.description"]', about.description);
+    renderList('[data-repeat="contact.about.cards"]', 'tpl-contact-about-card', about.cards || [], (node, item) => {
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+    });
+  }
+
+  function renderSimpleList(selector, items) {
+    const container = document.querySelector(selector);
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    (items || []).forEach((item) => {
+      const div = document.createElement('div');
+      div.textContent = item;
+      container.appendChild(div);
+    });
+  }
+})();

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -2,525 +2,247 @@
 {% block extra_head %}
   <style>
     .admin-dashboard {
-      max-width: 1200px;
+      max-width: 1080px;
       margin: 0 auto;
-      padding: 2rem 1.5rem 4rem;
-      display: grid;
-      gap: 2.5rem;
-    }
-
-    .admin-dashboard h1 {
-      margin-bottom: 0.5rem;
-    }
-
-    .admin-intro {
-      display: grid;
-      gap: 0.75rem;
-    }
-
-    .admin-sections {
+      padding: 2.5rem 1.5rem 4rem;
       display: grid;
       gap: 2rem;
     }
 
+    .admin-header {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .admin-header h1 {
+      margin: 0;
+      font-size: clamp(2rem, 3vw, 2.6rem);
+    }
+
+    .admin-header p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 720px;
+    }
+
+    .alert {
+      background: rgba(34, 197, 94, 0.12);
+      border: 1px solid rgba(34, 197, 94, 0.25);
+      color: #166534;
+      padding: 0.9rem 1.1rem;
+      border-radius: 14px;
+      font-weight: 600;
+    }
+
     .section-card {
       background: #ffffff;
-      border-radius: 20px;
-      padding: 1.75rem;
-      box-shadow: 0 25px 65px -45px rgba(15, 23, 42, 0.45);
+      border-radius: 22px;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      box-shadow: 0 32px 70px -55px rgba(15, 23, 42, 0.6);
+      padding: 1.8rem;
       display: grid;
       gap: 1.5rem;
     }
 
-    .section-card[data-section] {
-      border: 1px solid rgba(148, 163, 184, 0.18);
-    }
-
-    .section-toolbar {
+    .section-card header {
       display: flex;
+      align-items: center;
       justify-content: space-between;
-      align-items: flex-start;
-      gap: 1.5rem;
+      gap: 1rem;
     }
 
-    .section-toolbar h2 {
+    .section-card header h2 {
       margin: 0;
-      font-size: 1.3rem;
+      font-size: 1.35rem;
       color: var(--primary-dark);
     }
 
-    .section-toolbar p {
-      margin: 0.35rem 0 0;
+    .mode-status {
+      font-weight: 600;
+      margin: 0;
+    }
+
+    .mode-status.is-active {
+      color: #b91c1c;
+    }
+
+    .mode-actions {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .mode-actions p {
+      margin: 0;
       color: var(--muted);
     }
 
-    .edit-toggle {
+    .mode-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .mode-buttons form {
+      display: inline-flex;
+    }
+
+    .ghost-button {
+      border: 1px solid rgba(37, 99, 235, 0.35);
       border-radius: 999px;
-      border: 1px solid rgba(148, 163, 184, 0.55);
+      padding: 0.55rem 1.4rem;
+      font-weight: 600;
       background: #ffffff;
       color: var(--primary-dark);
-      padding: 0.35rem 1rem;
-      font-weight: 600;
       cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-      transition: all 0.2s ease-in-out;
     }
 
-    .edit-toggle::before {
-      content: '\270E';
-      font-size: 0.9rem;
-    }
-
-    .section-card.is-editing .edit-toggle {
-      background: var(--primary);
-      border-color: transparent;
-      color: #ffffff;
-      box-shadow: 0 12px 20px -12px rgba(37, 99, 235, 0.7);
-    }
-
-    .section-card.is-editing .edit-toggle::before {
-      content: '\2713';
-    }
-
-    .section-preview {
-      border: 2px dashed rgba(148, 163, 184, 0.25);
-      border-radius: 16px;
-      padding: 1rem 1.25rem;
-      background: rgba(241, 245, 249, 0.6);
+    .form-grid {
       display: grid;
-      gap: 1rem;
-      transition: all 0.2s ease-in-out;
+      gap: 1.25rem;
     }
 
-    .section-card.is-editing .section-preview {
-      border-color: rgba(37, 99, 235, 0.45);
-      background: rgba(59, 130, 246, 0.08);
-    }
-
-    .preview-grid {
-      display: grid;
-      gap: 0.75rem;
-    }
-
-    .preview-grid dl {
-      margin: 0;
-      display: grid;
-      gap: 0.15rem;
-    }
-
-    .preview-grid dt {
-      font-weight: 600;
-      font-size: 0.85rem;
-      letter-spacing: 0.02em;
-      text-transform: uppercase;
-      color: var(--muted);
-    }
-
-    .preview-grid dd {
-      margin: 0;
-    }
-
-    .preview-list {
-      margin: 0;
-      padding-left: 1rem;
-      color: var(--primary-dark);
-      display: grid;
-      gap: 0.25rem;
-    }
-
-    .color-swatches {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: 0.75rem;
-    }
-
-    .color-swatch {
-      display: grid;
-      gap: 0.35rem;
-      font-size: 0.9rem;
-    }
-
-    .color-swatch .swatch-label {
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      font-weight: 600;
-      font-size: 0.75rem;
-      color: var(--muted);
-    }
-
-    .color-swatch .swatch-color {
-      border-radius: 12px;
-      height: 36px;
-      border: 1px solid rgba(15, 23, 42, 0.08);
-    }
-
-    .color-swatch .swatch-value {
-      font-family: 'JetBrains Mono', monospace;
-      font-size: 0.85rem;
-    }
-
-    .field-help {
-      display: block;
-      margin-top: 0.35rem;
-      font-size: 0.8rem;
-      color: var(--muted);
-    }
-
-    .section-body {
-      display: none;
-      gap: 1.5rem;
-    }
-
-    .section-card.is-editing .section-body {
-      display: grid;
-    }
-
-    .form-fields {
+    .form-row {
       display: grid;
       gap: 1rem;
     }
 
-    .form-fields label {
+    .form-row.two-column {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .form-field {
       display: grid;
       gap: 0.4rem;
       font-weight: 600;
     }
 
-    .form-fields label.toggle-option {
-      display: flex;
-      align-items: flex-start;
-      gap: 0.75rem;
-      font-weight: 600;
-    }
-
-    .form-fields label.toggle-option input[type='checkbox'] {
-      width: 1.2rem;
-      height: 1.2rem;
-      margin-top: 0.2rem;
-    }
-
-    .form-fields label.toggle-option .toggle-label {
-      display: grid;
-      gap: 0.25rem;
-    }
-
-    .form-fields label.toggle-option .toggle-title {
-      font-weight: 600;
-    }
-
-    .form-fields input,
-    .form-fields textarea,
-    .form-fields select {
+    .form-field input,
+    .form-field textarea,
+    .form-field select {
       padding: 0.75rem 1rem;
       border-radius: 12px;
-      border: 1px solid rgba(100, 116, 139, 0.25);
+      border: 1px solid rgba(148, 163, 184, 0.35);
       font: inherit;
+      background: #ffffff;
+    }
+
+    .form-field textarea {
+      min-height: 110px;
       resize: vertical;
-      background: #ffffff;
     }
 
-    .form-fields textarea {
-      min-height: 120px;
-    }
-
-    .collection-wrapper {
-      position: relative;
-      border: 2px dashed rgba(148, 163, 184, 0.35);
-      border-radius: 18px;
-      padding: 1rem;
+    .color-grid {
       display: grid;
       gap: 1rem;
-      background: rgba(248, 250, 252, 0.55);
-      transition: all 0.2s ease-in-out;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     }
 
-    .collection-wrapper:hover {
-      border-color: rgba(37, 99, 235, 0.6);
-      background: rgba(59, 130, 246, 0.08);
-    }
-
-    .collection {
+    .color-grid label {
       display: grid;
-      gap: 1rem;
-    }
-
-    .collection-item {
-      border: 1px solid rgba(100, 116, 139, 0.25);
-      border-radius: 16px;
-      padding: 1rem;
-      display: grid;
-      gap: 0.75rem;
-      background: #ffffff;
-      box-shadow: 0 18px 40px -38px rgba(15, 23, 42, 0.6);
-    }
-
-    .collection-item-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
+      gap: 0.35rem;
       font-weight: 600;
-    }
-
-    .collection-item button.remove-item {
-      background: none;
-      border: none;
-      color: var(--muted);
-      cursor: pointer;
       font-size: 0.9rem;
-    }
-
-    .add-item {
-      justify-self: center;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      border: 1px solid rgba(37, 99, 235, 0.45);
-      border-radius: 999px;
-      padding: 0.35rem 1.1rem 0.35rem 0.6rem;
-      font-weight: 600;
-      color: var(--primary-dark);
-      background: #ffffff;
-      cursor: pointer;
-      transition: all 0.2s ease-in-out;
-      opacity: 0;
-      transform: translateY(-8px);
-    }
-
-    .add-item::before {
-      content: '+';
-      width: 1.75rem;
-      height: 1.75rem;
-      border-radius: 999px;
-      background: var(--primary);
-      color: #ffffff;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.1rem;
-    }
-
-    .collection-wrapper:hover .add-item,
-    .section-card.is-editing .collection-wrapper .add-item {
-      opacity: 1;
-      transform: translateY(0);
-    }
-
-    .admin-actions {
-      display: flex;
-      justify-content: flex-end;
-      padding-top: 0.5rem;
-    }
-
-    .admin-actions button {
-      padding-inline: 2.5rem;
-    }
-
-    .alert {
-      background: rgba(34, 197, 94, 0.12);
-      color: #15803d;
-      padding: 0.85rem 1rem;
-      border-radius: 12px;
-      font-weight: 600;
-    }
-
-    .image-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 1rem;
-    }
-
-    .image-grid figure {
-      border: 1px solid rgba(100, 116, 139, 0.2);
-      border-radius: 14px;
-      padding: 1rem;
-      background: #ffffff;
-      display: grid;
-      gap: 0.5rem;
-      justify-items: center;
-    }
-
-    .image-grid img {
-      max-width: 100%;
-      border-radius: 8px;
-    }
-
-    .color-inputs {
-      display: grid;
-      gap: 0.75rem;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-
-    .color-inputs label {
-      align-items: center;
-      grid-template-columns: 1fr auto;
-    }
-
-    .color-inputs input[type='color'] {
-      width: 52px;
-      height: 36px;
-      padding: 0;
-      border: none;
-      background: none;
     }
 
     .file-note {
-      font-size: 0.9rem;
+      font-size: 0.85rem;
       color: var(--muted);
     }
 
-    @media (max-width: 720px) {
-      .section-toolbar {
-        flex-direction: column;
-        align-items: stretch;
+    @media (max-width: 768px) {
+      .admin-toolbar {
+        inset: auto 1rem 1rem 1rem;
       }
 
-      .edit-toggle {
-        justify-content: center;
-      }
-
-      .section-preview {
-        padding: 1rem;
+      body.admin-mode-active {
+        padding-top: 5rem;
       }
     }
   </style>
 {% endblock %}
 {% block content %}
   <section class="admin-dashboard">
-    <div class="admin-intro">
-      <h1>Content management</h1>
-      <p>Hover a section to reveal quick add controls and click <strong>Edit section</strong> to update copy, colors, and lists. Changes are saved directly to the site database.</p>
+    <div class="admin-header">
+      <h1>Site settings</h1>
+      <p>
+        Manage the global configuration for your print studio. Use the admin mode toggle to edit
+        page content directly while previewing updates in real time.
+      </p>
       {% if message %}
         <div class="alert">{{ message }}</div>
       {% endif %}
     </div>
 
-    <form method="post" class="admin-sections">
-      <input type="hidden" name="action" value="update_content" />
-      <datalist id="media-options">
-        <option value=""></option>
-        {% for upload in uploads %}
-          <option value="/uploads/{{ upload }}">/uploads/{{ upload }}</option>
-        {% endfor %}
-      </datalist>
+    <article class="section-card">
+      <header>
+        <h2>Admin mode</h2>
+      </header>
+      <div class="mode-actions">
+        {% if admin_mode %}
+          <p class="mode-status is-active">Admin mode is currently active.</p>
+          <p>Browse the public pages to edit content. Save or discard your draft when you are ready.</p>
+          <div class="mode-buttons">
+            <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+              <input type="hidden" name="action" value="save_exit" />
+              <input type="hidden" name="next" value="{{ request.path }}" />
+              <button class="primary-button" type="submit">Save &amp; exit</button>
+            </form>
+            <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+              <input type="hidden" name="action" value="discard_exit" />
+              <input type="hidden" name="next" value="{{ request.path }}" />
+              <button class="ghost-button" type="submit">Discard draft</button>
+            </form>
+          </div>
+        {% else %}
+          <p class="mode-status">Admin mode is off.</p>
+          <p>Turn it on to open the inline editors on each page and preview updates before publishing.</p>
+          <div class="mode-buttons">
+            <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+              <input type="hidden" name="action" value="enter" />
+              <input type="hidden" name="next" value="{{ url_for('home') }}" />
+              <button class="primary-button" type="submit">Enter admin mode</button>
+            </form>
+          </div>
+        {% endif %}
+      </div>
+    </article>
 
-      <article class="section-card is-editing" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Admin access</h2>
-            <p>Manage the password required to sign in</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="true">Done</button>
+    <form method="post" class="section-card">
+      <header>
+        <h2>Branding &amp; theme</h2>
+      </header>
+      <input type="hidden" name="action" value="update_site_settings" />
+      <div class="form-grid">
+        <div class="form-row two-column">
+          <label class="form-field">
+            Business name
+            <input type="text" name="site_name" value="{{ content.site.name }}" required />
+          </label>
+          <label class="form-field">
+            Tagline
+            <input type="text" name="site_tagline" value="{{ content.site.tagline }}" />
+          </label>
         </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Password status</dt>
-              <dd>
-                {% if admin_password_state == 'custom' %}
-                  Custom password set
-                {% elif admin_password_state == 'empty' %}
-                  Password cleared (no password required)
-                {% else %}
-                  Using default password
-                {% endif %}
-              </dd>
-            </dl>
-          </div>
+        <div class="form-row">
+          <label class="form-field">
+            Footer description
+            <textarea name="footer_description">{{ content.site.footer.description }}</textarea>
+          </label>
         </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>
-              Set new admin password
-              <input type="password" name="admin_password" placeholder="Enter new password" autocomplete="new-password" />
-              <span class="field-help">Leave blank to keep the existing password. Launch with <code>--clear-admin-password</code> to reset to the default.</span>
-            </label>
-          </div>
+        <div class="form-row two-column">
+          <label class="form-field">
+            Footer visit lines (one per row)
+            <textarea name="footer_visit_lines">{{ content.site.footer.visit.lines | join('\n') }}</textarea>
+          </label>
+          <label class="form-field">
+            Footer contact lines (Label|URL — leave URL empty for plain text)
+            <textarea name="footer_contact_lines">{% for line in content.site.footer.contact.lines %}{{ line.label }}{% if line.url %}|{{ line.url }}{% endif %}{% if not loop.last %}\n{% endif %}{% endfor %}</textarea>
+          </label>
         </div>
-      </article>
-
-      <article class="section-card is-editing" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Site identity &amp; theme</h2>
-            <p>Brand, navigation, and global colors</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="true">Done</button>
-        </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Business name</dt>
-              <dd>{{ content.site.name }}</dd>
-            </dl>
-            <dl>
-              <dt>Tagline</dt>
-              <dd>{{ content.site.tagline or '–' }}</dd>
-            </dl>
-            <dl>
-              <dt>Admin border</dt>
-              <dd>
-                {% if content.site.flags.show_admin_border %}
-                  Enabled
-                {% else %}
-                  Disabled
-                {% endif %}
-              </dd>
-            </dl>
-            <div class="color-swatches">
-              <div class="color-swatch">
-                <span class="swatch-label">Primary</span>
-                <span class="swatch-color" style="background: {{ content.site.colors.primary }}"></span>
-                <span class="swatch-value">{{ content.site.colors.primary }}</span>
-              </div>
-              <div class="color-swatch">
-                <span class="swatch-label">Accent</span>
-                <span class="swatch-color" style="background: {{ content.site.colors.accent }}"></span>
-                <span class="swatch-value">{{ content.site.colors.accent }}</span>
-              </div>
-              <div class="color-swatch">
-                <span class="swatch-label">Background</span>
-                <span class="swatch-color" style="background: {{ content.site.colors.background }}"></span>
-                <span class="swatch-value">{{ content.site.colors.background }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
+        <div class="form-row">
+          <div class="color-grid">
             <label>
-              Business name
-              <input type="text" name="site_name" value="{{ content.site.name }}" required />
-            </label>
-            <label>
-              Tagline
-              <input type="text" name="site_tagline" value="{{ content.site.tagline }}" />
-            </label>
-          </div>
-          <div class="form-fields">
-            <label class="toggle-option">
-              <input
-                type="checkbox"
-                name="site_show_admin_border"
-                {% if content.site.flags.show_admin_border %}checked{% endif %}
-              />
-              <span class="toggle-label">
-                <span class="toggle-title">Show red admin border on site pages</span>
-                <span class="field-help">Adds a red border around public pages to confirm when the highlight mode is active.</span>
-              </span>
-            </label>
-          </div>
-          <div class="form-fields">
-            <label>
-              Footer description
-              <textarea name="footer_description">{{ content.site.footer.description }}</textarea>
-            </label>
-          </div>
-          <div class="color-inputs">
-            <label>
-              Primary
+              Primary color
               <input type="color" name="color_primary" value="{{ content.site.colors.primary }}" />
             </label>
             <label>
@@ -536,7 +258,7 @@
               <input type="color" name="color_background" value="{{ content.site.colors.background }}" />
             </label>
             <label>
-              Text
+              Body text
               <input type="color" name="color_text" value="{{ content.site.colors.text }}" />
             </label>
             <label>
@@ -544,553 +266,43 @@
               <input type="color" name="color_muted" value="{{ content.site.colors.muted }}" />
             </label>
           </div>
-          <div class="form-fields">
-            <label>
-              Footer visit lines (one per row)
-              <textarea name="footer_visit_lines">{{ content.site.footer.visit.lines | join('\n') }}</textarea>
-            </label>
-            <label>
-              Footer contact lines (Label|URL — leave URL empty for plain text)
-              <textarea name="footer_contact_lines">{% for line in content.site.footer.contact.lines %}{{ line.label }}{% if line.url %}|{{ line.url }}{% endif %}{% if not loop.last %}\n{% endif %}{% endfor %}</textarea>
-            </label>
-          </div>
         </div>
-      </article>
-
-      <article class="section-card" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Home page</h2>
-            <p>Hero, services overview, trust builders</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="false">Edit section</button>
+        <div class="form-row">
+          <label class="form-field">
+            Set new admin password
+            <input type="password" name="admin_password" placeholder="Enter new password" autocomplete="new-password" />
+            <span class="field-help">
+              {% if admin_password_state == 'custom' %}
+                Using a custom password.
+              {% elif admin_password_state == 'empty' %}
+                No password is currently required.
+              {% else %}
+                The default password is active.
+              {% endif %}
+            </span>
+          </label>
         </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Hero title</dt>
-              <dd>{{ home.hero.title }}</dd>
-            </dl>
-            <dl>
-              <dt>Hero call-to-action</dt>
-              <dd>{{ home.hero.cta_text or '–' }}</dd>
-            </dl>
-            <ul class="preview-list">
-              <li>{{ home['what_we_print'].title }} ({{ home['what_we_print']['items'] | length }} cards)</li>
-              <li>{{ home['why_choose'].title }} ({{ home['why_choose']['items'] | length }} highlights)</li>
-              <li>{{ home['testimonials'].title }} ({{ home['testimonials']['items'] | length }} quotes)</li>
-            </ul>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>Hero badge <input type="text" name="home_hero_badge" value="{{ home.hero.badge }}" /></label>
-            <label>Hero title <input type="text" name="home_hero_title" value="{{ home.hero.title }}" /></label>
-            <label>
-              Hero description
-              <textarea name="home_hero_description">{{ home.hero.description }}</textarea>
-            </label>
-            <label>Hero CTA text <input type="text" name="home_hero_cta_text" value="{{ home.hero.cta_text }}" /></label>
-            <label>Hero CTA link <input type="text" name="home_hero_cta_link" value="{{ home.hero.cta_link }}" /></label>
-            <label>Hero image path
-              <input type="text" name="home_hero_image" value="{{ home.hero.image }}" list="media-options" />
-            </label>
-            <label>Hero image alt text <input type="text" name="home_hero_image_alt" value="{{ home.hero.image_alt }}" /></label>
-          </div>
-
-          <h3>{{ home.what_we_print.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="home_what_we_print_heading" value="{{ home.what_we_print.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="home_what_we_print">
-              {% for item in home.what_we_print['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Card {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="home_what_we_print_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="home_what_we_print_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Card image (optional)
-                    <input
-                      type="text"
-                      name="home_what_we_print_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Card image alt text
-                    <input
-                      type="text"
-                      name="home_what_we_print_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                  <label>Bullet list (one per line)
-                    <textarea name="home_what_we_print_bullets">{{ item.bullets | join('\n') }}</textarea>
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="home_what_we_print_template">Add card</button>
-          </div>
-          <template id="home_what_we_print_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New card</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="home_what_we_print_title" /></label>
-              <label>Description <textarea name="home_what_we_print_description"></textarea></label>
-              <label>
-                Card image (optional)
-                <input type="text" name="home_what_we_print_image" list="media-options" />
-              </label>
-              <label>
-                Card image alt text
-                <input type="text" name="home_what_we_print_image_alt" />
-              </label>
-              <label>Bullet list (one per line)
-                <textarea name="home_what_we_print_bullets"></textarea>
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ home.why_choose.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="home_why_choose_heading" value="{{ home.why_choose.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="home_why_choose">
-              {% for item in home.why_choose['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Card {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="home_why_choose_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="home_why_choose_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Icon/image (optional)
-                    <input
-                      type="text"
-                      name="home_why_choose_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Image alt text
-                    <input
-                      type="text"
-                      name="home_why_choose_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="home_why_choose_template">Add highlight</button>
-          </div>
-          <template id="home_why_choose_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New highlight</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="home_why_choose_title" /></label>
-              <label>Description <textarea name="home_why_choose_description"></textarea></label>
-              <label>
-                Icon/image (optional)
-                <input type="text" name="home_why_choose_image" list="media-options" />
-              </label>
-              <label>
-                Image alt text
-                <input type="text" name="home_why_choose_image_alt" />
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ home.testimonials.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="home_testimonials_heading" value="{{ home.testimonials.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="home_testimonials">
-              {% for item in home.testimonials['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Testimonial {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Quote <textarea name="home_testimonials_quote">{{ item.quote }}</textarea></label>
-                  <label>Attribution <input type="text" name="home_testimonials_author" value="{{ item.author }}" /></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="home_testimonials_template">Add testimonial</button>
-          </div>
-          <template id="home_testimonials_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New testimonial</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Quote <textarea name="home_testimonials_quote"></textarea></label>
-              <label>Attribution <input type="text" name="home_testimonials_author" /></label>
-            </div>
-          </template>
-        </div>
-      </article>
-
-      <article class="section-card" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Services page</h2>
-            <p>Capabilities, bundles, and process</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="false">Edit section</button>
-        </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Hero title</dt>
-              <dd>{{ services.hero.title }}</dd>
-            </dl>
-            <ul class="preview-list">
-              <li>{{ services['capabilities'].title }} ({{ services['capabilities']['items'] | length }} capabilities)</li>
-              <li>{{ services['bundles'].title }} ({{ services['bundles']['items'] | length }} bundles)</li>
-              <li>{{ services.process.title }} ({{ services.process.steps | length }} steps)</li>
-            </ul>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>Hero badge <input type="text" name="services_hero_badge" value="{{ services.hero.badge }}" /></label>
-            <label>Hero title <input type="text" name="services_hero_title" value="{{ services.hero.title }}" /></label>
-            <label>Hero description <textarea name="services_hero_description">{{ services.hero.description }}</textarea></label>
-          </div>
-
-          <h3>{{ services.capabilities.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="services_capabilities_heading" value="{{ services.capabilities.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="services_capabilities">
-              {% for item in services.capabilities['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Capability {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="services_capabilities_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="services_capabilities_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Feature image (optional)
-                    <input
-                      type="text"
-                      name="services_capabilities_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Image alt text
-                    <input
-                      type="text"
-                      name="services_capabilities_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                  <label>Bullet list (one per line)
-                    <textarea name="services_capabilities_bullets">{{ item.bullets | join('\n') }}</textarea>
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="services_capabilities_template">Add capability</button>
-          </div>
-          <template id="services_capabilities_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New capability</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="services_capabilities_title" /></label>
-              <label>Description <textarea name="services_capabilities_description"></textarea></label>
-              <label>
-                Feature image (optional)
-                <input type="text" name="services_capabilities_image" list="media-options" />
-              </label>
-              <label>
-                Image alt text
-                <input type="text" name="services_capabilities_image_alt" />
-              </label>
-              <label>Bullet list (one per line)
-                <textarea name="services_capabilities_bullets"></textarea>
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ services.bundles.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="services_bundles_heading" value="{{ services.bundles.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="services_bundles">
-              {% for item in services.bundles['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Bundle {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="services_bundles_title" value="{{ item.title }}" /></label>
-                  <label>Price <input type="text" name="services_bundles_price" value="{{ item.price }}" /></label>
-                  <label>Description <textarea name="services_bundles_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Bundle image (optional)
-                    <input
-                      type="text"
-                      name="services_bundles_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Image alt text
-                    <input
-                      type="text"
-                      name="services_bundles_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                  <label>Bullet list (one per line)
-                    <textarea name="services_bundles_bullets">{{ item.bullets | join('\n') }}</textarea>
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="services_bundles_template">Add bundle</button>
-          </div>
-          <template id="services_bundles_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New bundle</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="services_bundles_title" /></label>
-              <label>Price <input type="text" name="services_bundles_price" /></label>
-              <label>Description <textarea name="services_bundles_description"></textarea></label>
-              <label>
-                Bundle image (optional)
-                <input type="text" name="services_bundles_image" list="media-options" />
-              </label>
-              <label>
-                Image alt text
-                <input type="text" name="services_bundles_image_alt" />
-              </label>
-              <label>Bullet list (one per line)
-                <textarea name="services_bundles_bullets"></textarea>
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ services.process.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="services_process_heading" value="{{ services.process.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="services_process">
-              {% for item in services.process.steps %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Step {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="services_process_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="services_process_description">{{ item.description }}</textarea></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="services_process_template">Add step</button>
-          </div>
-          <template id="services_process_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New step</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="services_process_title" /></label>
-              <label>Description <textarea name="services_process_description"></textarea></label>
-            </div>
-          </template>
-          <div class="form-fields">
-            <label>Process CTA title <input type="text" name="services_process_cta_title" value="{{ services.process.cta.title }}" /></label>
-            <label>Process CTA description <textarea name="services_process_cta_description">{{ services.process.cta.description }}</textarea></label>
-            <label>Process CTA button text <input type="text" name="services_process_cta_text" value="{{ services.process.cta.text }}" /></label>
-            <label>Process CTA link <input type="text" name="services_process_cta_link" value="{{ services.process.cta.link }}" /></label>
-          </div>
-        </div>
-      </article>
-
-      <article class="section-card" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Contact page</h2>
-            <p>Location, business hours, and form fields</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="false">Edit section</button>
-        </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Hero title</dt>
-              <dd>{{ contact.hero.title }}</dd>
-            </dl>
-            <dl>
-              <dt>Studio phone</dt>
-              <dd>{{ contact.studio.phone or '–' }}</dd>
-            </dl>
-            <ul class="preview-list">
-              <li>{{ contact.form.fields | length }} form fields</li>
-              <li>{{ contact.about.cards | length }} about cards</li>
-            </ul>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>Hero badge <input type="text" name="contact_hero_badge" value="{{ contact.hero.badge }}" /></label>
-            <label>Hero title <input type="text" name="contact_hero_title" value="{{ contact.hero.title }}" /></label>
-            <label>Hero description <textarea name="contact_hero_description">{{ contact.hero.description }}</textarea></label>
-          </div>
-          <div class="form-fields">
-            <label>Visit title <input type="text" name="contact_visit_title" value="{{ contact.studio.visit_title }}" /></label>
-            <label>Address (one per line)
-              <textarea name="contact_address_lines">{{ contact.studio.address | join('\n') }}</textarea>
-            </label>
-            <label>Hours title <input type="text" name="contact_hours_title" value="{{ contact.studio.hours_title }}" /></label>
-            <label>Hours (one per line)
-              <textarea name="contact_hours_lines">{{ contact.studio.hours | join('\n') }}</textarea>
-            </label>
-            <label>Phone label <input type="text" name="contact_phone_title" value="{{ contact.studio.phone_title }}" /></label>
-            <label>Phone number <input type="text" name="contact_phone" value="{{ contact.studio.phone }}" /></label>
-            <label>Phone link <input type="text" name="contact_phone_href" value="{{ contact.studio.phone_href }}" /></label>
-            <label>Email label <input type="text" name="contact_email_title" value="{{ contact.studio.email_title }}" /></label>
-            <label>Email address <input type="email" name="contact_email" value="{{ contact.studio.email }}" /></label>
-          </div>
-          <div class="form-fields">
-            <label>Form title <input type="text" name="contact_form_title" value="{{ contact.form.title }}" /></label>
-            <label>Submit button text <input type="text" name="contact_form_submit" value="{{ contact.form.submit_text }}" /></label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="contact_form_fields">
-              {% for field in contact.form.fields %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Field {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Label <input type="text" name="contact_form_label" value="{{ field.label }}" /></label>
-                  <label>Name <input type="text" name="contact_form_name" value="{{ field.name }}" /></label>
-                  <label>Type
-                    <select name="contact_form_type">
-                      <option value="text" {% if field.type == 'text' %}selected{% endif %}>Text</option>
-                      <option value="email" {% if field.type == 'email' %}selected{% endif %}>Email</option>
-                      <option value="textarea" {% if field.type == 'textarea' %}selected{% endif %}>Textarea</option>
-                    </select>
-                  </label>
-                  <label>Placeholder <input type="text" name="contact_form_placeholder" value="{{ field.placeholder }}" /></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="contact_form_template">Add form field</button>
-          </div>
-          <template id="contact_form_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New field</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Label <input type="text" name="contact_form_label" /></label>
-              <label>Name <input type="text" name="contact_form_name" /></label>
-              <label>Type
-                <select name="contact_form_type">
-                  <option value="text">Text</option>
-                  <option value="email">Email</option>
-                  <option value="textarea">Textarea</option>
-                </select>
-              </label>
-              <label>Placeholder <input type="text" name="contact_form_placeholder" /></label>
-            </div>
-          </template>
-
-          <h3>{{ contact.about.title }}</h3>
-          <label>About title <input type="text" name="contact_about_title" value="{{ contact.about.title }}" /></label>
-          <label>About description <textarea name="contact_about_description">{{ contact.about.description }}</textarea></label>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="contact_about_cards">
-              {% for card in contact.about.cards %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Card {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="contact_about_title_item" value="{{ card.title }}" /></label>
-                  <label>Description <textarea name="contact_about_description_item">{{ card.description }}</textarea></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="contact_about_template">Add card</button>
-          </div>
-          <template id="contact_about_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New card</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="contact_about_title_item" /></label>
-              <label>Description <textarea name="contact_about_description_item"></textarea></label>
-            </div>
-          </template>
-        </div>
-      </article>
-
-      <div class="admin-actions">
-        <button class="primary-button" type="submit">Save changes</button>
       </div>
+      <button class="primary-button" type="submit">Save settings</button>
     </form>
 
     <article class="section-card">
-      <div class="section-toolbar">
-        <div>
-          <h2>Media library</h2>
-          <p>Upload hero images or gallery assets</p>
-        </div>
-      </div>
+      <header>
+        <h2>Media library</h2>
+      </header>
       <form method="post" enctype="multipart/form-data">
         <input type="hidden" name="action" value="upload_media" />
-        <div class="form-fields">
-          <label>Upload image
+        <div class="form-row two-column">
+          <label class="form-field">
+            Upload image
             <input type="file" name="media" accept="image/*" />
           </label>
-          <div class="file-note">Files are stored in <code>{{ webroot_path }}/uploads</code> and can be referenced by using <code>/uploads/&lt;filename&gt;</code> in image fields.</div>
-          <button class="primary-button" type="submit">Upload file</button>
+          <div class="file-note">
+            Files are saved to <code>{{ webroot_path }}/uploads</code>. Reference them with
+            <code>/uploads/&lt;filename&gt;</code> when editing page content.
+          </div>
         </div>
+        <button class="primary-button" type="submit">Upload file</button>
       </form>
       {% if uploads %}
         <div class="image-grid">
@@ -1107,44 +319,4 @@
     </article>
   </section>
 {% endblock %}
-{% block extra_scripts %}
-  <script>
-    const sections = document.querySelectorAll('[data-section]');
-    sections.forEach((section, index) => {
-      const toggle = section.querySelector('.edit-toggle');
-      if (!toggle) return;
-      if (index !== 0) {
-        toggle.textContent = 'Edit section';
-        toggle.setAttribute('aria-expanded', 'false');
-      }
-      toggle.addEventListener('click', () => {
-        const isEditing = section.classList.toggle('is-editing');
-        toggle.textContent = isEditing ? 'Done' : 'Edit section';
-        toggle.setAttribute('aria-expanded', String(isEditing));
-      });
-    });
-
-    document.querySelectorAll('.add-item').forEach((button) => {
-      button.addEventListener('click', () => {
-        const template = document.getElementById(button.dataset.template);
-        if (!template) return;
-        const clone = template.content.firstElementChild.cloneNode(true);
-        const wrapper = button.closest('.collection-wrapper');
-        const collection = wrapper?.querySelector('.collection');
-        collection?.appendChild(clone);
-        attachRemoveHandlers(clone);
-      });
-    });
-
-    function attachRemoveHandlers(scope = document) {
-      scope.querySelectorAll('.remove-item').forEach((button) => {
-        button.addEventListener('click', () => {
-          const item = button.closest('.collection-item');
-          item?.remove();
-        });
-      });
-    }
-
-    attachRemoveHandlers();
-  </script>
-{% endblock %}
+{% block extra_scripts %}{% endblock %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -188,6 +188,28 @@
       font-weight: 600;
     }
 
+    .form-fields label.toggle-option {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      font-weight: 600;
+    }
+
+    .form-fields label.toggle-option input[type='checkbox'] {
+      width: 1.2rem;
+      height: 1.2rem;
+      margin-top: 0.2rem;
+    }
+
+    .form-fields label.toggle-option .toggle-label {
+      display: grid;
+      gap: 0.25rem;
+    }
+
+    .form-fields label.toggle-option .toggle-title {
+      font-weight: 600;
+    }
+
     .form-fields input,
     .form-fields textarea,
     .form-fields select {
@@ -437,6 +459,16 @@
               <dt>Tagline</dt>
               <dd>{{ content.site.tagline or '–' }}</dd>
             </dl>
+            <dl>
+              <dt>Admin border</dt>
+              <dd>
+                {% if content.site.flags.show_admin_border %}
+                  Enabled
+                {% else %}
+                  Disabled
+                {% endif %}
+              </dd>
+            </dl>
             <div class="color-swatches">
               <div class="color-swatch">
                 <span class="swatch-label">Primary</span>
@@ -465,6 +497,19 @@
             <label>
               Tagline
               <input type="text" name="site_tagline" value="{{ content.site.tagline }}" />
+            </label>
+          </div>
+          <div class="form-fields">
+            <label class="toggle-option">
+              <input
+                type="checkbox"
+                name="site_show_admin_border"
+                {% if content.site.flags.show_admin_border %}checked{% endif %}
+              />
+              <span class="toggle-label">
+                <span class="toggle-title">Show red admin border on site pages</span>
+                <span class="field-help">Adds a red border around public pages to confirm when the highlight mode is active.</span>
+              </span>
             </label>
           </div>
           <div class="form-fields">

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -369,7 +369,7 @@
   <section class="admin-dashboard">
     <div class="admin-intro">
       <h1>Content management</h1>
-      <p>Hover a section to reveal quick add controls and click <strong>Edit section</strong> to update copy, colors, and lists. Changes are saved to <code>{{ webroot_path }}/content.json</code>.</p>
+      <p>Hover a section to reveal quick add controls and click <strong>Edit section</strong> to update copy, colors, and lists. Changes are saved directly to the site database.</p>
       {% if message %}
         <div class="alert">{{ message }}</div>
       {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,31 @@
     </style>
     {% block extra_head %}{% endblock %}
   </head>
-  <body class="{{ body_class|default('', true) }}">
+  <body
+    class="{{ body_class|default('', true) }}"
+    data-page-key="{{ page_key|default('', true) }}"
+    data-admin-mode="{{ 1 if admin_mode|default(false) else 0 }}"
+  >
+    {% if admin_mode|default(false) %}
+      <div class="admin-toolbar" role="status">
+        <span class="admin-toolbar__label">Admin mode is active</span>
+        <a class="admin-toolbar__link" href="{{ url_for('admin_dashboard') }}">Site settings</a>
+        <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+          <input type="hidden" name="action" value="save_exit" />
+          <input type="hidden" name="next" value="{{ request.path }}" />
+          <button type="submit" class="admin-toolbar__button admin-toolbar__button--primary">
+            Save &amp; exit
+          </button>
+        </form>
+        <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+          <input type="hidden" name="action" value="discard_exit" />
+          <input type="hidden" name="next" value="{{ request.path }}" />
+          <button type="submit" class="admin-toolbar__button admin-toolbar__button--ghost">
+            Discard draft
+          </button>
+        </form>
+      </div>
+    {% endif %}
     <header>
       <div class="navbar">
         <a class="logo" href="{{ url_for('home') }}">{{ content.site.name }}</a>
@@ -92,6 +116,9 @@
     <script>
       document.getElementById('year').textContent = new Date().getFullYear();
     </script>
+    {% if admin_mode|default(false) %}
+      <script src="{{ url_for('static', filename='js/admin-mode.js') }}" defer></script>
+    {% endif %}
     {% block extra_scripts %}{% endblock %}
   </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,7 +66,7 @@
             {% endfor %}
             <li>
               <a
-                href="{{ url_for('admin_dashboard') }}"
+                href="{{ url_for('admin_login') }}"
                 class="admin-link {% if request.path.startswith('/admin') %}active{% endif %}"
                 >Admin</a
               >

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,64 +1,177 @@
 {% extends 'base.html' %}
 {% block content %}
-  <section class="hero">
+  {% if admin_mode %}
+    <div class="page-editor is-open" data-page-editor="contact">
+      <div class="page-editor__header">
+        <h2 class="page-editor__title">Contact page editor</h2>
+        <button type="button" class="page-editor__toggle" data-editor-toggle>Hide editor</button>
+      </div>
+      <form class="page-editor__body" data-editor-form>
+        <input type="hidden" name="page" value="contact" />
+        <p class="editor-hint">Keep location, form fields, and about text up to date from here.</p>
+        <div class="form-fields">
+          <label>Hero badge <input type="text" name="contact_hero_badge" value="{{ contact.hero.badge }}" /></label>
+          <label>Hero title <input type="text" name="contact_hero_title" value="{{ contact.hero.title }}" /></label>
+          <label>Hero description <textarea name="contact_hero_description">{{ contact.hero.description }}</textarea></label>
+        </div>
+
+        <h3>Studio information</h3>
+        <div class="form-fields">
+          <label>Visit title <input type="text" name="contact_visit_title" value="{{ contact.studio.visit_title }}" /></label>
+          <label>Address lines <textarea name="contact_address_lines">{{ contact.studio.address | join('\n') }}</textarea></label>
+          <label>Hours title <input type="text" name="contact_hours_title" value="{{ contact.studio.hours_title }}" /></label>
+          <label>Hours lines <textarea name="contact_hours_lines">{{ contact.studio.hours | join('\n') }}</textarea></label>
+          <label>Phone title <input type="text" name="contact_phone_title" value="{{ contact.studio.phone_title }}" /></label>
+          <label>Phone number <input type="text" name="contact_phone" value="{{ contact.studio.phone }}" /></label>
+          <label>Phone link (tel:) <input type="text" name="contact_phone_href" value="{{ contact.studio.phone_href }}" /></label>
+          <label>Email title <input type="text" name="contact_email_title" value="{{ contact.studio.email_title }}" /></label>
+          <label>Email address <input type="email" name="contact_email" value="{{ contact.studio.email }}" /></label>
+        </div>
+
+        <h3>Contact form</h3>
+        <div class="form-fields">
+          <label>Form title <input type="text" name="contact_form_title" value="{{ contact.form.title }}" /></label>
+          <label>Submit button <input type="text" name="contact_form_submit" value="{{ contact.form.submit_text }}" /></label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="contact_form">
+            {% for field in contact.form.fields %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Field {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Label <input type="text" name="contact_form_label" value="{{ field.label }}" /></label>
+                <label>Name <input type="text" name="contact_form_name" value="{{ field.name }}" /></label>
+                <label>Type
+                  <select name="contact_form_type">
+                    <option value="text" {% if field.type == 'text' %}selected{% endif %}>Text</option>
+                    <option value="email" {% if field.type == 'email' %}selected{% endif %}>Email</option>
+                    <option value="textarea" {% if field.type == 'textarea' %}selected{% endif %}>Textarea</option>
+                  </select>
+                </label>
+                <label>Placeholder <input type="text" name="contact_form_placeholder" value="{{ field.placeholder }}" /></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="contact_form_template">Add field</button>
+        </div>
+        <template id="contact_form_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New field</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Label <input type="text" name="contact_form_label" /></label>
+            <label>Name <input type="text" name="contact_form_name" /></label>
+            <label>Type
+              <select name="contact_form_type">
+                <option value="text">Text</option>
+                <option value="email">Email</option>
+                <option value="textarea">Textarea</option>
+              </select>
+            </label>
+            <label>Placeholder <input type="text" name="contact_form_placeholder" /></label>
+          </div>
+        </template>
+
+        <h3>About section</h3>
+        <div class="form-fields">
+          <label>About title <input type="text" name="contact_about_title" value="{{ contact.about.title }}" /></label>
+          <label>About description <textarea name="contact_about_description">{{ contact.about.description }}</textarea></label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="contact_about">
+            {% for card in contact.about.cards %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Card {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="contact_about_title_item" value="{{ card.title }}" /></label>
+                <label>Description <textarea name="contact_about_description_item">{{ card.description }}</textarea></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="contact_about_template">Add card</button>
+        </div>
+        <template id="contact_about_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New card</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="contact_about_title_item" /></label>
+            <label>Description <textarea name="contact_about_description_item"></textarea></label>
+          </div>
+        </template>
+      </form>
+    </div>
+  {% endif %}
+
+  <section class="hero" data-preview-section="contact-hero">
     <div class="hero-content">
       <div>
-        <span class="badge">{{ contact.hero.badge }}</span>
-        <h1>{{ contact.hero.title }}</h1>
-        <p>{{ contact.hero.description }}</p>
+        <span class="badge" data-slot="contact.hero.badge">{{ contact.hero.badge }}</span>
+        <h1 data-slot="contact.hero.title">{{ contact.hero.title }}</h1>
+        <p data-slot="contact.hero.description">{{ contact.hero.description }}</p>
       </div>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-preview-section="contact-details">
     <div class="grid" style="max-width: 960px">
-      <div class="contact-card">
-        <strong>{{ contact.studio.visit_title }}</strong>
-        <div>
+      <div class="contact-card" data-preview-studio>
+        <strong data-slot="contact.studio.visit_title">{{ contact.studio.visit_title }}</strong>
+        <div data-list="contact.studio.address">
           {% for line in contact.studio.address %}
-            {{ line }}<br />
-          {% endfor %}
-        </div>
-        <div>
-          <strong>{{ contact.studio.hours_title }}</strong>
-          {% for line in contact.studio.hours %}
             <div>{{ line }}</div>
           {% endfor %}
         </div>
         <div>
-          <strong>{{ contact.studio.phone_title }}</strong>
-          <a href="tel:{{ contact.studio.phone_href }}">{{ contact.studio.phone }}</a>
+          <strong data-slot="contact.studio.hours_title">{{ contact.studio.hours_title }}</strong>
+          <div data-list="contact.studio.hours">
+            {% for line in contact.studio.hours %}
+              <div>{{ line }}</div>
+            {% endfor %}
+          </div>
         </div>
         <div>
-          <strong>{{ contact.studio.email_title }}</strong>
-          <a href="mailto:{{ contact.studio.email }}">{{ contact.studio.email }}</a>
+          <strong data-slot="contact.studio.phone_title">{{ contact.studio.phone_title }}</strong>
+          <a href="tel:{{ contact.studio.phone_href }}" data-slot-link="contact.studio.phone">{{ contact.studio.phone }}</a>
+        </div>
+        <div>
+          <strong data-slot="contact.studio.email_title">{{ contact.studio.email_title }}</strong>
+          <a href="mailto:{{ contact.studio.email }}" data-slot-link="contact.studio.email">{{ contact.studio.email }}</a>
         </div>
       </div>
 
-      <div class="contact-card">
-        <strong>{{ contact.form.title }}</strong>
+      <div class="contact-card" data-preview-form>
+        <strong data-slot="contact.form.title">{{ contact.form.title }}</strong>
         <form class="contact-form">
-          {% for field in contact.form.fields %}
-            <label>
-              {{ field.label }}
-              {% if field.type == 'textarea' %}
-                <textarea name="{{ field.name }}" placeholder="{{ field.placeholder }}"></textarea>
-              {% else %}
-                <input type="{{ field.type }}" name="{{ field.name }}" placeholder="{{ field.placeholder }}" />
-              {% endif %}
-            </label>
-          {% endfor %}
-          <button class="primary-button" type="submit">{{ contact.form.submit_text }}</button>
+          <div data-repeat="contact.form.fields">
+            {% for field in contact.form.fields %}
+              <label data-field>
+                <span class="field-label">{{ field.label }}</span>
+                {% if field.type == 'textarea' %}
+                  <textarea name="{{ field.name }}" placeholder="{{ field.placeholder }}"></textarea>
+                {% else %}
+                  <input type="{{ field.type }}" name="{{ field.name }}" placeholder="{{ field.placeholder }}" />
+                {% endif %}
+              </label>
+            {% endfor %}
+          </div>
+          <button class="primary-button" type="submit" data-slot="contact.form.submit_text">{{ contact.form.submit_text }}</button>
         </form>
       </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="contact-about">
     <div class="grid" style="max-width: 900px">
-      <h2>{{ contact.about.title }}</h2>
-      <p>{{ contact.about.description }}</p>
-      <div class="grid grid-3">
+      <h2 data-slot="contact.about.title">{{ contact.about.title }}</h2>
+      <p data-slot="contact.about.description">{{ contact.about.description }}</p>
+      <div class="grid grid-3" data-repeat="contact.about.cards">
         {% for card in contact.about.cards %}
           <article class="card">
             <h3>{{ card.title }}</h3>
@@ -68,4 +181,19 @@
       </div>
     </div>
   </section>
+
+  {% if admin_mode %}
+    <template id="tpl-contact-form-field">
+      <label data-field>
+        <span class="field-label"></span>
+        <input type="text" />
+      </label>
+    </template>
+    <template id="tpl-contact-about-card">
+      <article class="card">
+        <h3></h3>
+        <p></p>
+      </article>
+    </template>
+  {% endif %}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,58 +1,227 @@
 {% extends 'base.html' %}
 {% block content %}
-  <section class="hero">
+  {% if admin_mode %}
+    <div class="page-editor is-open" data-page-editor="home">
+      <div class="page-editor__header">
+        <h2 class="page-editor__title">Home page editor</h2>
+        <button type="button" class="page-editor__toggle" data-editor-toggle>Hide editor</button>
+      </div>
+      <form class="page-editor__body" data-editor-form>
+        <input type="hidden" name="page" value="home" />
+        <p class="editor-hint">Updates apply to the live page preview only while admin mode is active.</p>
+        <div class="form-fields">
+          <label>Hero badge <input type="text" name="home_hero_badge" value="{{ home.hero.badge }}" /></label>
+          <label>Hero title <input type="text" name="home_hero_title" value="{{ home.hero.title }}" /></label>
+          <label>
+            Hero description
+            <textarea name="home_hero_description">{{ home.hero.description }}</textarea>
+          </label>
+          <label>Hero CTA text <input type="text" name="home_hero_cta_text" value="{{ home.hero.cta_text }}" /></label>
+          <label>Hero CTA link <input type="text" name="home_hero_cta_link" value="{{ home.hero.cta_link }}" /></label>
+          <label>
+            Hero image path
+            <input type="text" name="home_hero_image" value="{{ home.hero.image }}" list="media-options" />
+          </label>
+          <label>Hero image alt text <input type="text" name="home_hero_image_alt" value="{{ home.hero.image_alt }}" /></label>
+        </div>
+
+        <h3>{{ home.what_we_print.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="home_what_we_print_heading" value="{{ home.what_we_print.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="home_what_we_print">
+            {% for item in home.what_we_print['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Card {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="home_what_we_print_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="home_what_we_print_description">{{ item.description }}</textarea></label>
+                <label>
+                  Card image
+                  <input type="text" name="home_what_we_print_image" value="{{ item.image }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="home_what_we_print_image_alt" value="{{ item.image_alt }}" />
+                </label>
+                <label>Bullet list (one per line)
+                  <textarea name="home_what_we_print_bullets">{{ item.bullets | join('\n') }}</textarea>
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="home_what_we_print_template">Add card</button>
+        </div>
+        <template id="home_what_we_print_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New card</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="home_what_we_print_title" /></label>
+            <label>Description <textarea name="home_what_we_print_description"></textarea></label>
+            <label>
+              Card image
+              <input type="text" name="home_what_we_print_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="home_what_we_print_image_alt" />
+            </label>
+            <label>Bullet list (one per line)
+              <textarea name="home_what_we_print_bullets"></textarea>
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ home.why_choose.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="home_why_choose_heading" value="{{ home.why_choose.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="home_why_choose">
+            {% for item in home.why_choose['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Highlight {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="home_why_choose_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="home_why_choose_description">{{ item.description }}</textarea></label>
+                <label>
+                  Icon/image
+                  <input type="text" name="home_why_choose_image" value="{{ item.image | default('', true) }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="home_why_choose_image_alt" value="{{ item.image_alt | default('', true) }}" />
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="home_why_choose_template">Add highlight</button>
+        </div>
+        <template id="home_why_choose_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New highlight</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="home_why_choose_title" /></label>
+            <label>Description <textarea name="home_why_choose_description"></textarea></label>
+            <label>
+              Icon/image
+              <input type="text" name="home_why_choose_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="home_why_choose_image_alt" />
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ home.testimonials.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="home_testimonials_heading" value="{{ home.testimonials.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="home_testimonials">
+            {% for item in home.testimonials['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Testimonial {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Quote <textarea name="home_testimonials_quote">{{ item.quote }}</textarea></label>
+                <label>Attribution <input type="text" name="home_testimonials_author" value="{{ item.author }}" /></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="home_testimonials_template">Add testimonial</button>
+        </div>
+        <template id="home_testimonials_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New testimonial</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Quote <textarea name="home_testimonials_quote"></textarea></label>
+            <label>Attribution <input type="text" name="home_testimonials_author" /></label>
+          </div>
+        </template>
+
+        <datalist id="media-options">
+          <option value=""></option>
+          {% for upload in editor_uploads %}
+            <option value="/uploads/{{ upload }}">/uploads/{{ upload }}</option>
+          {% endfor %}
+        </datalist>
+      </form>
+    </div>
+  {% endif %}
+
+  <section class="hero" data-preview-section="home-hero">
     <div class="hero-content">
       <div>
-        <span class="badge">{{ home.hero.badge }}</span>
-        <h1>{{ home.hero.title }}</h1>
-        <p>{{ home.hero.description }}</p>
-        <a class="primary-button" href="{{ home.hero.cta_link }}">{{ home.hero.cta_text }}</a>
+        <span class="badge" data-slot="home.hero.badge">{{ home.hero.badge }}</span>
+        <h1 data-slot="home.hero.title">{{ home.hero.title }}</h1>
+        <p data-slot="home.hero.description">{{ home.hero.description }}</p>
+        <a class="primary-button" href="{{ home.hero.cta_link }}" data-slot-link="home.hero.cta">
+          {{ home.hero.cta_text }}
+        </a>
       </div>
-      {% if home.hero.image %}
-        <div class="hero-image">
+      <div class="hero-image" data-slot-container="home.hero.image" {% if not home.hero.image %}hidden{% endif %}>
+        {% if home.hero.image %}
           <img src="{{ home.hero.image }}" alt="{{ home.hero.image_alt }}" />
-        </div>
-      {% endif %}
+        {% endif %}
+      </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="home-what-we-print">
     <div class="grid">
-      <h2>{{ home.what_we_print.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="home.what_we_print.title">{{ home.what_we_print.title }}</h2>
+      <div class="grid grid-3" data-repeat="home.what_we_print.items">
         {% for item in home.what_we_print["items"] %}
           <article class="card">
-            {% if item.image %}
-              <div class="card-media">
+            <div class="card-media" data-image-container {% if not item.image %}hidden{% endif %}>
+              {% if item.image %}
                 <img src="{{ item.image }}" alt="{{ item.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ item.title }}</h3>
             <p>{{ item.description }}</p>
-            {% if item.bullets %}
-              <ul class="checklist">
-                {% for bullet in item.bullets %}
-                  <li>{{ bullet }}</li>
-                {% endfor %}
-              </ul>
-            {% endif %}
+            <ul class="checklist" data-list {% if not item.bullets %}hidden{% endif %}>
+              {% for bullet in item.bullets %}
+                <li>{{ bullet }}</li>
+              {% endfor %}
+            </ul>
           </article>
         {% endfor %}
       </div>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-preview-section="home-why-choose">
     <div class="grid">
-      <h2>{{ home.why_choose.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="home.why_choose.title">{{ home.why_choose.title }}</h2>
+      <div class="grid grid-3" data-repeat="home.why_choose.items">
         {% for item in home.why_choose["items"] %}
           <article class="card">
-            {% if item.image %}
-              <div class="card-media compact">
+            <div class="card-media compact" data-image-container {% if not item.image %}hidden{% endif %}>
+              {% if item.image %}
                 <img src="{{ item.image }}" alt="{{ item.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ item.title }}</h3>
             <p>{{ item.description }}</p>
           </article>
@@ -61,10 +230,10 @@
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="home-testimonials">
     <div class="grid">
-      <h2>{{ home.testimonials.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="home.testimonials.title">{{ home.testimonials.title }}</h2>
+      <div class="grid grid-3" data-repeat="home.testimonials.items">
         {% for testimonial in home.testimonials["items"] %}
           <article class="card testimonial">
             <p>{{ testimonial.quote }}</p>
@@ -74,4 +243,28 @@
       </div>
     </div>
   </section>
+
+  {% if admin_mode %}
+    <template id="tpl-home-what-we-print">
+      <article class="card">
+        <div class="card-media" data-image-container hidden></div>
+        <h3></h3>
+        <p></p>
+        <ul class="checklist" data-list hidden></ul>
+      </article>
+    </template>
+    <template id="tpl-home-why-choose">
+      <article class="card">
+        <div class="card-media compact" data-image-container hidden></div>
+        <h3></h3>
+        <p></p>
+      </article>
+    </template>
+    <template id="tpl-home-testimonial">
+      <article class="card testimonial">
+        <p></p>
+        <cite></cite>
+      </article>
+    </template>
+  {% endif %}
 {% endblock %}

--- a/templates/services.html
+++ b/templates/services.html
@@ -1,74 +1,245 @@
 {% extends 'base.html' %}
 {% block content %}
-  <section class="hero">
+  {% if admin_mode %}
+    <div class="page-editor is-open" data-page-editor="services">
+      <div class="page-editor__header">
+        <h2 class="page-editor__title">Services page editor</h2>
+        <button type="button" class="page-editor__toggle" data-editor-toggle>Hide editor</button>
+      </div>
+      <form class="page-editor__body" data-editor-form>
+        <input type="hidden" name="page" value="services" />
+        <p class="editor-hint">Adjust copy, pricing, and workflow steps directly from this panel.</p>
+        <div class="form-fields">
+          <label>Hero badge <input type="text" name="services_hero_badge" value="{{ services.hero.badge }}" /></label>
+          <label>Hero title <input type="text" name="services_hero_title" value="{{ services.hero.title }}" /></label>
+          <label>Hero description <textarea name="services_hero_description">{{ services.hero.description }}</textarea></label>
+        </div>
+
+        <h3>{{ services.capabilities.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="services_capabilities_heading" value="{{ services.capabilities.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="services_capabilities">
+            {% for item in services.capabilities['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Capability {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="services_capabilities_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="services_capabilities_description">{{ item.description }}</textarea></label>
+                <label>
+                  Feature image
+                  <input type="text" name="services_capabilities_image" value="{{ item.image | default('', true) }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="services_capabilities_image_alt" value="{{ item.image_alt | default('', true) }}" />
+                </label>
+                <label>Bullet list (one per line)
+                  <textarea name="services_capabilities_bullets">{{ item.bullets | join('\n') }}</textarea>
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="services_capabilities_template">Add capability</button>
+        </div>
+        <template id="services_capabilities_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New capability</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="services_capabilities_title" /></label>
+            <label>Description <textarea name="services_capabilities_description"></textarea></label>
+            <label>
+              Feature image
+              <input type="text" name="services_capabilities_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="services_capabilities_image_alt" />
+            </label>
+            <label>Bullet list (one per line)
+              <textarea name="services_capabilities_bullets"></textarea>
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ services.bundles.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="services_bundles_heading" value="{{ services.bundles.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="services_bundles">
+            {% for item in services.bundles['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Bundle {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="services_bundles_title" value="{{ item.title }}" /></label>
+                <label>Price <input type="text" name="services_bundles_price" value="{{ item.price }}" /></label>
+                <label>Description <textarea name="services_bundles_description">{{ item.description }}</textarea></label>
+                <label>
+                  Bundle image
+                  <input type="text" name="services_bundles_image" value="{{ item.image | default('', true) }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="services_bundles_image_alt" value="{{ item.image_alt | default('', true) }}" />
+                </label>
+                <label>Bullet list (one per line)
+                  <textarea name="services_bundles_bullets">{{ item.bullets | join('\n') }}</textarea>
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="services_bundles_template">Add bundle</button>
+        </div>
+        <template id="services_bundles_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New bundle</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="services_bundles_title" /></label>
+            <label>Price <input type="text" name="services_bundles_price" /></label>
+            <label>Description <textarea name="services_bundles_description"></textarea></label>
+            <label>
+              Bundle image
+              <input type="text" name="services_bundles_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="services_bundles_image_alt" />
+            </label>
+            <label>Bullet list (one per line)
+              <textarea name="services_bundles_bullets"></textarea>
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ services.process.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="services_process_heading" value="{{ services.process.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="services_process">
+            {% for item in services.process.steps %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Step {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="services_process_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="services_process_description">{{ item.description }}</textarea></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="services_process_template">Add step</button>
+        </div>
+        <template id="services_process_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New step</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="services_process_title" /></label>
+            <label>Description <textarea name="services_process_description"></textarea></label>
+          </div>
+        </template>
+
+        <div class="form-fields">
+          <label>Call-to-action title <input type="text" name="services_process_cta_title" value="{{ services.process.cta.title }}" /></label>
+          <label>
+            Call-to-action description
+            <textarea name="services_process_cta_description">{{ services.process.cta.description }}</textarea>
+          </label>
+          <label>Button text <input type="text" name="services_process_cta_text" value="{{ services.process.cta.text }}" /></label>
+          <label>Button link <input type="text" name="services_process_cta_link" value="{{ services.process.cta.link }}" /></label>
+        </div>
+
+        <datalist id="media-options">
+          <option value=""></option>
+          {% for upload in editor_uploads %}
+            <option value="/uploads/{{ upload }}">/uploads/{{ upload }}</option>
+          {% endfor %}
+        </datalist>
+      </form>
+    </div>
+  {% endif %}
+
+  <section class="hero" data-preview-section="services-hero">
     <div class="hero-content">
       <div class="service-hero">
-        <span class="badge">{{ services.hero.badge }}</span>
-        <h1>{{ services.hero.title }}</h1>
-        <p>{{ services.hero.description }}</p>
+        <span class="badge" data-slot="services.hero.badge">{{ services.hero.badge }}</span>
+        <h1 data-slot="services.hero.title">{{ services.hero.title }}</h1>
+        <p data-slot="services.hero.description">{{ services.hero.description }}</p>
       </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="services-capabilities">
     <div class="grid">
-      <h2>{{ services.capabilities.title }}</h2>
-      <div class="grid grid-3">
-        {% for item in services.capabilities["items"] %}
+      <h2 data-slot="services.capabilities.title">{{ services.capabilities.title }}</h2>
+      <div class="grid grid-3" data-repeat="services.capabilities.items">
+        {% for item in services.capabilities['items'] %}
           <article class="card">
-            {% if item.image %}
-              <div class="card-media">
+            <div class="card-media" data-image-container {% if not item.image %}hidden{% endif %}>
+              {% if item.image %}
                 <img src="{{ item.image }}" alt="{{ item.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ item.title }}</h3>
             <p>{{ item.description }}</p>
-            {% if item.bullets %}
-              <ul class="checklist">
-                {% for bullet in item.bullets %}
-                  <li>{{ bullet }}</li>
-                {% endfor %}
-              </ul>
-            {% endif %}
+            <ul class="checklist" data-list {% if not item.bullets %}hidden{% endif %}>
+              {% for bullet in item.bullets %}
+                <li>{{ bullet }}</li>
+              {% endfor %}
+            </ul>
           </article>
         {% endfor %}
       </div>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-preview-section="services-bundles">
     <div class="grid">
-      <h2>{{ services.bundles.title }}</h2>
-      <div class="grid grid-3">
-        {% for bundle in services.bundles["items"] %}
+      <h2 data-slot="services.bundles.title">{{ services.bundles.title }}</h2>
+      <div class="grid grid-3" data-repeat="services.bundles.items">
+        {% for bundle in services.bundles['items'] %}
           <article class="card">
-            {% if bundle.image %}
-              <div class="card-media">
+            <div class="card-media" data-image-container {% if not bundle.image %}hidden{% endif %}>
+              {% if bundle.image %}
                 <img src="{{ bundle.image }}" alt="{{ bundle.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ bundle.title }}</h3>
-            {% if bundle.price %}
-              <div class="price">{{ bundle.price }}</div>
-            {% endif %}
+            <div class="price" data-slot="services.bundles.price">{{ bundle.price }}</div>
             <p>{{ bundle.description }}</p>
-            {% if bundle.bullets %}
-              <ul class="checklist">
-                {% for bullet in bundle.bullets %}
-                  <li>{{ bullet }}</li>
-                {% endfor %}
-              </ul>
-            {% endif %}
+            <ul class="checklist" data-list {% if not bundle.bullets %}hidden{% endif %}>
+              {% for bullet in bundle.bullets %}
+                <li>{{ bullet }}</li>
+              {% endfor %}
+            </ul>
           </article>
         {% endfor %}
       </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="services-process">
     <div class="grid" style="max-width: 980px">
-      <h2>{{ services.process.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="services.process.title">{{ services.process.title }}</h2>
+      <div class="grid grid-3" data-repeat="services.process.steps">
         {% for step in services.process.steps %}
           <article class="card">
             <h3>{{ step.title }}</h3>
@@ -76,11 +247,39 @@
           </article>
         {% endfor %}
       </div>
-      <div class="card" style="margin-top: 2rem; text-align: center">
-        <h3>{{ services.process.cta.title }}</h3>
-        <p>{{ services.process.cta.description }}</p>
-        <a class="primary-button" href="{{ services.process.cta.link }}">{{ services.process.cta.text }}</a>
+      <div class="card" style="margin-top: 2rem; text-align: center" data-preview-cta>
+        <h3 data-slot="services.process.cta.title">{{ services.process.cta.title }}</h3>
+        <p data-slot="services.process.cta.description">{{ services.process.cta.description }}</p>
+        <a class="primary-button" href="{{ services.process.cta.link }}" data-slot-link="services.process.cta">
+          {{ services.process.cta.text }}
+        </a>
       </div>
     </div>
   </section>
+
+  {% if admin_mode %}
+    <template id="tpl-services-capability">
+      <article class="card">
+        <div class="card-media" data-image-container hidden></div>
+        <h3></h3>
+        <p></p>
+        <ul class="checklist" data-list hidden></ul>
+      </article>
+    </template>
+    <template id="tpl-services-bundle">
+      <article class="card">
+        <div class="card-media" data-image-container hidden></div>
+        <h3></h3>
+        <div class="price"></div>
+        <p></p>
+        <ul class="checklist" data-list hidden></ul>
+      </article>
+    </template>
+    <template id="tpl-services-step">
+      <article class="card">
+        <h3></h3>
+        <p></p>
+      </article>
+    </template>
+  {% endif %}
 {% endblock %}

--- a/webroot/content.json
+++ b/webroot/content.json
@@ -34,8 +34,7 @@
         ]
       },
       "copyright": "All rights reserved."
-    },
-    "flags": { "show_admin_border": false }
+    }
   },
   "pages": {
     "home": {

--- a/webroot/content.json
+++ b/webroot/content.json
@@ -34,7 +34,8 @@
         ]
       },
       "copyright": "All rights reserved."
-    }
+    },
+    "flags": { "show_admin_border": false }
   },
   "pages": {
     "home": {


### PR DESCRIPTION
## Summary
- replace the file-based content and password storage with a SQLite settings table managed through SQLAlchemy
- update the admin dashboard copy to reflect database-backed persistence
- refresh review documentation and dependencies for the new storage approach

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e5b6b89bd083339307dbfc11bb113e