### PR TITLE
Add storefront page backed by printer inventory

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,14 @@
+# Code Review Suggestions
+
+## 1. Harden admin authentication
+* Hash the admin password instead of storing it as plaintext in the `settings` table, and require the default to be rotated on first login. The current implementation reads and writes the password value directly, so anyone with database access can recover it and the default remains active indefinitely.【F:app.py†L88-L109】
+* Consider refusing to start the app if `SECRET_KEY` is left at the default so session cookies remain protected in production deployments.【F:app.py†L28-L33】
+
+## 2. Tighten upload handling
+* The media upload path accepts any file type and saves it verbatim. Introduce an allow-list of MIME types/extensions, enforce size limits, and store files under generated names to avoid collisions or executable uploads that could be served back to users.【F:app.py†L524-L533】
+
+## 3. Expand draft safety controls
+* Admin mode now persists unsaved edits in a shared `drafts` table keyed only by the session cookie. Consider adding automatic cleanup for abandoned drafts, per-user identifiers, or change history so concurrent editors don't overwrite each other and operators can revert to prior revisions if a draft is accidentally saved.【F:app.py†L152-L213】【F:app.py†L560-L590】
+
+## 4. Improve mobile experience controls
+* `should_use_mobile_alt` relies solely on User-Agent sniffing and cannot be overridden once detected. Consider a persistent user preference (cookie or query param) so users can opt out of the mobile template, and expand detection to cover modern tablet UAs more accurately.【F:app.py†L614-L629】

--- a/app.py
+++ b/app.py
@@ -1,12 +1,17 @@
 import argparse
 import json
 import os
-import shutil
+import re
+from copy import deepcopy
 from functools import wraps
+from math import ceil
 from pathlib import Path
+from urllib.parse import urlparse
+from uuid import uuid4
 
 from flask import (
     Flask,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -15,212 +20,438 @@ from flask import (
     url_for,
 )
 from werkzeug.utils import secure_filename
+from sqlalchemy import Column, String, Text, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 BASE_DIR = Path(__file__).parent.resolve()
 DEFAULT_WEBROOT = BASE_DIR / "webroot"
 WEBROOT_PATH = Path(os.environ.get("WEBROOT_PATH", DEFAULT_WEBROOT))
-CONTENT_FILE = WEBROOT_PATH / "content.json"
 UPLOAD_FOLDER = WEBROOT_PATH / "uploads"
 
-ADMIN_PASSWORD_FILE = WEBROOT_PATH / "admin_password.txt"
 DEFAULT_ADMIN_PASSWORD = "printstudio"
 SECRET_KEY = os.environ.get("SECRET_KEY", "change-me-please")
+DATABASE_FILE = WEBROOT_PATH / "site.db"
+DEFAULT_PRINTER_INVENTORY = DEFAULT_WEBROOT / "printer_inventory.json"
+DEFAULT_CONTENT_FILE = DEFAULT_WEBROOT / "content.json"
+
+
+def _load_default_store_assets() -> tuple[dict, dict]:
+    fallback_store = {
+        "meta": {"title": "Printer Store"},
+        "hero": {
+            "badge": "Printer Store",
+            "title": "Shop enterprise-ready laser printers",
+            "description": "Explore curated HP, Canon, Kyocera, and Toshiba models with toner pairings we trust for reliable office output.",
+            "cta_text": "Talk with a print specialist",
+            "cta_link": "/contact",
+        },
+        "promises": {
+            "title": "Every order includes",
+            "items": [
+                {
+                    "title": "Configured for your workflow",
+                    "description": "We stage firmware updates, network settings, and driver bundles so installations are plug-and-play.",
+                },
+                {
+                    "title": "Guaranteed supply matching",
+                    "description": "Each listing includes the toner SKUs we stock, so you never guess about refills.",
+                },
+                {
+                    "title": "Local service and delivery",
+                    "description": "Our technicians can deliver, install, and keep your fleet humming across the Coastal Bend.",
+                },
+            ],
+        },
+        "support": {
+            "title": "Need a tailored print plan?",
+            "description": "Bundle printers, managed supplies, and priority service into one agreement built for your team.",
+            "cta_text": "Request a custom quote",
+            "cta_link": "/contact",
+        },
+    }
+    try:
+        with DEFAULT_CONTENT_FILE.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return fallback_store, {"label": "Store", "url": "/store"}
+
+    navigation = data.get("site", {}).get("navigation", [])
+    store_nav = next((item for item in navigation if item.get("url") == "/store"), None)
+    store_page = data.get("pages", {}).get("store") or fallback_store
+    return store_page, store_nav or {"label": "Store", "url": "/store"}
+
+
+def _build_default_printer_image_map() -> dict[tuple[str | None, str | None], dict[str, str]]:
+    try:
+        with DEFAULT_PRINTER_INVENTORY.open("r", encoding="utf-8") as fh:
+            inventory = json.load(fh)
+    except FileNotFoundError:
+        return {}
+
+    mapping: dict[tuple[str | None, str | None], dict[str, str]] = {}
+    for manufacturer in inventory.get("manufacturers", []):
+        name = manufacturer.get("name")
+        for model in manufacturer.get("models", []):
+            mapping[(name, model.get("model"))] = {
+                "image": model.get("image", ""),
+                "image_alt": model.get("image_alt", ""),
+            }
+    return mapping
+
+
+DEFAULT_STORE_PAGE_TEMPLATE, DEFAULT_STORE_NAV_ITEM = _load_default_store_assets()
+DEFAULT_PRINTER_IMAGE_MAP = _build_default_printer_image_map()
+
+
+def _merge_defaults(target: dict, defaults: dict) -> dict:
+    for key, value in defaults.items():
+        if key not in target:
+            target[key] = deepcopy(value)
+        elif isinstance(value, dict) and isinstance(target[key], dict):
+            _merge_defaults(target[key], value)
+    return target
 
 app = Flask(__name__)
 app.config.update(SECRET_KEY=SECRET_KEY)
 
+Base = declarative_base()
+engine = None
+SessionLocal = None
 
-def ensure_webroot() -> None:
+
+class Setting(Base):
+    __tablename__ = "settings"
+
+    key = Column(String(100), primary_key=True)
+    value = Column(Text, nullable=False)
+
+
+class Draft(Base):
+    __tablename__ = "drafts"
+
+    id = Column(String(64), primary_key=True)
+    value = Column(Text, nullable=False)
+
+
+def ensure_directories() -> None:
     WEBROOT_PATH.mkdir(parents=True, exist_ok=True)
     UPLOAD_FOLDER.mkdir(parents=True, exist_ok=True)
-    if not ADMIN_PASSWORD_FILE.exists():
-        ADMIN_PASSWORD_FILE.write_text(DEFAULT_ADMIN_PASSWORD, encoding="utf-8")
-    if not CONTENT_FILE.exists():
-        if WEBROOT_PATH != DEFAULT_WEBROOT and (DEFAULT_WEBROOT / "content.json").exists():
-            shutil.copy(DEFAULT_WEBROOT / "content.json", CONTENT_FILE)
-        else:
+
+
+def init_db() -> None:
+    ensure_directories()
+    global engine, SessionLocal
+    if engine is None or SessionLocal is None:
+        database_uri = f"sqlite:///{DATABASE_FILE}"
+        engine = create_engine(
+            database_uri, future=True, connect_args={"check_same_thread": False}
+        )
+        SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        Base.metadata.create_all(engine)
+
+    assert SessionLocal is not None
+    with SessionLocal() as session:
+        created_defaults = False
+        if session.get(Setting, "admin_password") is None:
+            session.add(Setting(key="admin_password", value=json.dumps(DEFAULT_ADMIN_PASSWORD)))
+            created_defaults = True
+        if session.get(Setting, "content") is None:
             default_content = load_default_content()
-            save_content(default_content)
+            session.add(Setting(key="content", value=json.dumps(default_content)))
+            created_defaults = True
+        if session.get(Setting, "printer_inventory") is None:
+            default_inventory = load_default_printer_inventory()
+            session.add(
+                Setting(key="printer_inventory", value=json.dumps(default_inventory))
+            )
+            created_defaults = True
+        if created_defaults:
+            session.commit()
+
+
+def ensure_webroot() -> None:
+    init_db()
 
 
 def load_admin_password() -> str:
     ensure_webroot()
-    return ADMIN_PASSWORD_FILE.read_text(encoding="utf-8").strip()
+    assert SessionLocal is not None
+    with SessionLocal() as session:
+        record = session.get(Setting, "admin_password")
+        if record is None:
+            save_admin_password(DEFAULT_ADMIN_PASSWORD)
+            return DEFAULT_ADMIN_PASSWORD
+        return json.loads(record.value)
 
 
 def save_admin_password(value: str) -> None:
     ensure_webroot()
-    ADMIN_PASSWORD_FILE.write_text(value, encoding="utf-8")
+    stored_value = json.dumps(value)
+    assert SessionLocal is not None
+    with SessionLocal() as session:
+        record = session.get(Setting, "admin_password")
+        if record is None:
+            session.add(Setting(key="admin_password", value=stored_value))
+        else:
+            record.value = stored_value
+        session.commit()
 
 
 def load_default_content() -> dict:
     with (DEFAULT_WEBROOT / "content.json").open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return ensure_content_defaults(data)
+
+
+def load_default_printer_inventory() -> dict:
+    with DEFAULT_PRINTER_INVENTORY.open("r", encoding="utf-8") as fh:
         return json.load(fh)
+
+
+def ensure_content_defaults(content: dict) -> dict:
+    site = content.setdefault("site", {})
+    flags = site.setdefault("flags", {})
+    if "show_admin_border" in flags:
+        flags.pop("show_admin_border", None)
+    navigation = site.setdefault("navigation", [])
+    if not any(item.get("url") == "/store" for item in navigation):
+        insert_at = next(
+            (index for index, item in enumerate(navigation) if item.get("url") == "/contact"),
+            len(navigation),
+        )
+        navigation.insert(insert_at, deepcopy(DEFAULT_STORE_NAV_ITEM))
+
+    pages = content.setdefault("pages", {})
+    store_defaults = deepcopy(DEFAULT_STORE_PAGE_TEMPLATE)
+    store = pages.get("store")
+    if not isinstance(store, dict):
+        pages["store"] = store_defaults
+    else:
+        _merge_defaults(store, store_defaults)
+        if isinstance(store.get("promises"), dict) and not store["promises"].get("items"):
+            store["promises"]["items"] = deepcopy(store_defaults["promises"]["items"])
+    return content
+
+
+def ensure_printer_inventory_defaults(inventory: dict) -> tuple[dict, bool]:
+    changed = False
+    manufacturers = inventory.setdefault("manufacturers", [])
+    for manufacturer in manufacturers:
+        models = manufacturer.setdefault("models", [])
+        for model in models:
+            if not isinstance(model.get("cartridges"), list):
+                model["cartridges"] = []
+                changed = True
+            defaults = DEFAULT_PRINTER_IMAGE_MAP.get((manufacturer.get("name"), model.get("model")))
+            if defaults:
+                for field, value in defaults.items():
+                    if value and not model.get(field):
+                        model[field] = value
+                        changed = True
+            if not model.get("image"):
+                slug_base = f"{manufacturer.get('name', '')} {model.get('model', '')}".strip().lower()
+                slug = re.sub(r"[^a-z0-9]+", "-", slug_base).strip("-") or "printer"
+                static_path = Path("static/img/printers") / f"{slug}.svg"
+                candidate = BASE_DIR / static_path
+                if candidate.exists():
+                    model["image"] = f"/{static_path.as_posix()}"
+                    changed = True
+            if not model.get("image_alt") and model.get("model"):
+                manufacturer_name = manufacturer.get("name", "").strip()
+                model_name = model.get("model", "").strip()
+                if manufacturer_name or model_name:
+                    model["image_alt"] = (
+                        f"Stylized illustration of the {manufacturer_name} {model_name} laser printer"
+                    ).strip()
+                    changed = True
+    return inventory, changed
 
 
 def load_content() -> dict:
     ensure_webroot()
-    with CONTENT_FILE.open("r", encoding="utf-8") as fh:
-        return json.load(fh)
+    assert SessionLocal is not None
+    with SessionLocal() as session:
+        record = session.get(Setting, "content")
+        if record is None:
+            default_content = load_default_content()
+            session.add(Setting(key="content", value=json.dumps(default_content)))
+            session.commit()
+            return default_content
+        return ensure_content_defaults(json.loads(record.value))
 
 
 def save_content(data: dict) -> None:
     ensure_webroot()
-    with CONTENT_FILE.open("w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2, ensure_ascii=False)
+    assert SessionLocal is not None
+    stored_value = json.dumps(data, ensure_ascii=False, indent=2)
+    with SessionLocal() as session:
+        record = session.get(Setting, "content")
+        if record is None:
+            session.add(Setting(key="content", value=stored_value))
+        else:
+            record.value = stored_value
+        session.commit()
 
 
-def login_required(view):
-    @wraps(view)
-    def wrapped(*args, **kwargs):
-        if not session.get("admin_authenticated"):
-            return redirect(url_for("admin_login", next=request.path))
-        return view(*args, **kwargs)
-
-    return wrapped
-
-
-def split_lines(value: str) -> list[str]:
-    return [line.strip() for line in value.splitlines() if line.strip()]
-
-
-def page_title(content: dict, page_key: str) -> str:
-    meta = content["pages"].get(page_key, {}).get("meta", {})
-    return meta.get("title") or content["site"].get("tagline") or content["site"]["name"]
-
-
-@app.route("/")
-def home():
-    content = load_content()
-    if should_use_mobile_alt(request):
-        return render_mobile_home(content)
-    return render_template(
-        "index.html",
-        content=content,
-        theme=content["site"]["colors"],
-        home=content["pages"]["home"],
-        page_title=page_title(content, "home"),
-    )
-
-
-@app.route("/mobile")
-def mobile_home():
-    content = load_content()
-    return render_mobile_home(content)
-
-
-@app.route("/services")
-def services_page():
-    content = load_content()
-    return render_template(
-        "services.html",
-        content=content,
-        theme=content["site"]["colors"],
-        services=content["pages"]["services"],
-        page_title=page_title(content, "services"),
-    )
-
-
-@app.route("/contact")
-def contact_page():
-    content = load_content()
-    return render_template(
-        "contact.html",
-        content=content,
-        theme=content["site"]["colors"],
-        contact=content["pages"]["contact"],
-        page_title=page_title(content, "contact"),
-    )
-
-
-@app.route("/uploads/<path:filename>")
-def uploaded_file(filename: str):
+def load_printer_inventory() -> dict:
     ensure_webroot()
-    return send_from_directory(UPLOAD_FOLDER, filename)
+    assert SessionLocal is not None
+    with SessionLocal() as session:
+        record = session.get(Setting, "printer_inventory")
+        if record is None:
+            default_inventory = load_default_printer_inventory()
+            default_inventory, _ = ensure_printer_inventory_defaults(default_inventory)
+            session.add(
+                Setting(
+                    key="printer_inventory",
+                    value=json.dumps(default_inventory, ensure_ascii=False),
+                )
+            )
+            session.commit()
+            return default_inventory
+        data = json.loads(record.value)
+        data, changed = ensure_printer_inventory_defaults(data)
+        if changed:
+            record.value = json.dumps(data, ensure_ascii=False)
+            session.commit()
+        return data
 
 
-@app.route("/admin/login", methods=["GET", "POST"])
-def admin_login():
-    if session.get("admin_authenticated"):
-        return redirect(url_for("admin_dashboard"))
+def flatten_printer_inventory(inventory: dict) -> tuple[list[dict], list[dict]]:
+    printers: list[dict] = []
+    manufacturer_notes: list[dict] = []
+    for manufacturer in inventory.get("manufacturers", []):
+        name = manufacturer.get("name")
+        note = manufacturer.get("note")
+        models = manufacturer.get("models", [])
+        if note and not models:
+            manufacturer_notes.append({"manufacturer": name, "note": note})
+        for model in models:
+            entry = deepcopy(model)
+            entry["manufacturer"] = name
+            entry.setdefault("cartridges", [])
+            printers.append(entry)
 
-    error = None
-    if request.method == "POST":
-        password = request.form.get("password", "")
-        if password == load_admin_password():
-            session["admin_authenticated"] = True
-            next_url = request.args.get("next") or url_for("admin_dashboard")
-            return redirect(next_url)
-        error = "Incorrect password."
-    content = load_content()
-    return render_template(
-        "login.html",
-        content=content,
-        theme=content["site"]["colors"],
-        page_title="Admin",
-        error=error,
+    printers.sort(
+        key=lambda item: (
+            item.get("manufacturer") or "",
+            -1 * (item.get("release_year") or 0),
+            item.get("model") or "",
+        )
     )
+    return printers, manufacturer_notes
 
 
-@app.route("/admin/logout")
-def admin_logout():
-    session.pop("admin_authenticated", None)
-    return redirect(url_for("home"))
+def is_admin_authenticated() -> bool:
+    return bool(session.get("admin_authenticated"))
 
 
-@app.route("/admin", methods=["GET", "POST"])
-@login_required
-def admin_dashboard():
-    content = load_content()
-    message = session.pop("admin_message", None)
+def is_admin_mode() -> bool:
+    return bool(session.get("admin_mode"))
 
-    if request.method == "POST":
-        action = request.form.get("action")
-        if action == "update_content":
-            updated, password_changed = update_content_from_form(content, request.form)
-            save_content(updated)
-            message_text = "Changes saved successfully."
-            if password_changed:
-                message_text += " Admin password updated."
-            session["admin_message"] = message_text
-            return redirect(url_for("admin_dashboard"))
-        if action == "upload_media":
-            file = request.files.get("media")
-            if file and file.filename:
-                filename = secure_filename(file.filename)
-                destination = UPLOAD_FOLDER / filename
-                file.save(destination)
-                session["admin_message"] = f"Uploaded {filename}."
-            else:
-                session["admin_message"] = "Please choose an image to upload."
-            return redirect(url_for("admin_dashboard"))
 
-    uploads = sorted(
+def ensure_draft_session() -> str:
+    ensure_webroot()
+    draft_id = session.get("draft_id")
+    assert SessionLocal is not None
+    with SessionLocal() as db:
+        record = db.get(Draft, draft_id) if draft_id else None
+        if record is None:
+            draft_id = uuid4().hex
+            content = load_content()
+            db.add(Draft(id=draft_id, value=json.dumps(content, ensure_ascii=False)))
+            db.commit()
+        session["draft_id"] = draft_id
+        session.modified = True
+        return draft_id
+
+
+def load_draft_content() -> dict:
+    draft_id = ensure_draft_session()
+    assert SessionLocal is not None
+    with SessionLocal() as db:
+        record = db.get(Draft, draft_id)
+        if record is None:
+            return ensure_content_defaults(load_content())
+        return ensure_content_defaults(json.loads(record.value))
+
+
+def save_draft_content(data: dict) -> None:
+    draft_id = ensure_draft_session()
+    assert SessionLocal is not None
+    stored_value = json.dumps(data, ensure_ascii=False)
+    with SessionLocal() as db:
+        record = db.get(Draft, draft_id)
+        if record is None:
+            db.add(Draft(id=draft_id, value=stored_value))
+        else:
+            record.value = stored_value
+        db.commit()
+
+
+def clear_draft_content() -> None:
+    ensure_webroot()
+    draft_id = session.pop("draft_id", None)
+    session.pop("admin_mode", None)
+    if not draft_id:
+        return
+    assert SessionLocal is not None
+    with SessionLocal() as db:
+        record = db.get(Draft, draft_id)
+        if record is not None:
+            db.delete(record)
+            db.commit()
+
+
+def get_request_content() -> dict:
+    if is_admin_mode():
+        try:
+            return load_draft_content()
+        except Exception:
+            return load_content()
+    return load_content()
+
+
+def list_uploads() -> list[str]:
+    ensure_webroot()
+    if not UPLOAD_FOLDER.exists():
+        return []
+    return sorted(
         [f.name for f in UPLOAD_FOLDER.iterdir() if f.is_file() and not f.name.startswith(".")]
     )
-    password_value = load_admin_password()
-    if not password_value:
-        password_state = "empty"
-    elif password_value == DEFAULT_ADMIN_PASSWORD:
-        password_state = "default"
-    else:
-        password_state = "custom"
-    return render_template(
-        "admin.html",
-        content=content,
-        theme=content["site"]["colors"],
-        home=content["pages"]["home"],
-        services=content["pages"]["services"],
-        contact=content["pages"]["contact"],
-        page_title="Admin",
-        message=message,
-        uploads=uploads,
-        webroot_path=str(WEBROOT_PATH),
-        admin_password_state=password_state,
-    )
 
 
-def update_content_from_form(content: dict, form: "MultiDict") -> tuple[dict, bool]:
+@app.route("/api/printers")
+def api_printer_inventory() -> "Response":
+    return jsonify(load_printer_inventory())
+
+
+def safe_next_url(candidate: str | None) -> str:
+    if not candidate:
+        return url_for("home")
+    parsed = urlparse(candidate)
+    if parsed.scheme or parsed.netloc:
+        return url_for("home")
+    if not candidate.startswith("/"):
+        candidate = f"/{candidate}"
+    return candidate
+
+
+def enter_admin_mode() -> None:
+    session["admin_mode"] = True
+    session.modified = True
+    ensure_draft_session()
+
+
+def exit_admin_mode(save_changes: bool) -> None:
+    if save_changes:
+        draft_content = load_draft_content()
+        save_content(draft_content)
+    clear_draft_content()
+
+
+def update_site_settings_from_form(content: dict, form: "MultiDict") -> tuple[dict, bool]:
+    ensure_content_defaults(content)
     password_changed = False
     new_password = form.get("admin_password", "").strip()
     if new_password:
@@ -229,6 +460,7 @@ def update_content_from_form(content: dict, form: "MultiDict") -> tuple[dict, bo
     content["site"]["name"] = form.get("site_name", content["site"]["name"]).strip()
     content["site"]["tagline"] = form.get("site_tagline", "").strip()
     content["site"]["footer"]["description"] = form.get("footer_description", "").strip()
+
     colors = content["site"].setdefault("colors", {})
     colors["primary"] = form.get("color_primary", colors.get("primary", "#1d4ed8"))
     colors["primary_dark"] = form.get(
@@ -260,8 +492,10 @@ def update_content_from_form(content: dict, form: "MultiDict") -> tuple[dict, bo
             line_dict["url"] = url
         contact_lines.append(line_dict)
     content["site"]["footer"]["contact"]["lines"] = contact_lines
+    return content, password_changed
 
-    # Home page
+
+def update_home_page_from_form(content: dict, form: "MultiDict") -> dict:
     home = content["pages"]["home"]
     home["hero"]["badge"] = form.get("home_hero_badge", "").strip()
     home["hero"]["title"] = form.get("home_hero_title", "").strip()
@@ -272,15 +506,15 @@ def update_content_from_form(content: dict, form: "MultiDict") -> tuple[dict, bo
     home["hero"]["image_alt"] = form.get("home_hero_image_alt", "").strip()
 
     home["what_we_print"]["title"] = form.get("home_what_we_print_heading", "").strip()
-    home["what_we_print"]["items"] = parse_cards_with_bullets(
-        form, "home_what_we_print"
-    )
+    home["what_we_print"]["items"] = parse_cards_with_bullets(form, "home_what_we_print")
     home["why_choose"]["title"] = form.get("home_why_choose_heading", "").strip()
     home["why_choose"]["items"] = parse_cards(form, "home_why_choose")
     home["testimonials"]["title"] = form.get("home_testimonials_heading", "").strip()
     home["testimonials"]["items"] = parse_testimonials(form)
+    return home
 
-    # Services page
+
+def update_services_page_from_form(content: dict, form: "MultiDict") -> dict:
     services = content["pages"]["services"]
     services["hero"]["badge"] = form.get("services_hero_badge", "").strip()
     services["hero"]["title"] = form.get("services_hero_title", "").strip()
@@ -302,8 +536,10 @@ def update_content_from_form(content: dict, form: "MultiDict") -> tuple[dict, bo
     ).strip()
     services["process"]["cta"]["text"] = form.get("services_process_cta_text", "").strip()
     services["process"]["cta"]["link"] = form.get("services_process_cta_link", "").strip()
+    return services
 
-    # Contact page
+
+def update_contact_page_from_form(content: dict, form: "MultiDict") -> dict:
     contact = content["pages"]["contact"]
     contact["hero"]["badge"] = form.get("contact_hero_badge", "").strip()
     contact["hero"]["title"] = form.get("contact_hero_title", "").strip()
@@ -326,7 +562,354 @@ def update_content_from_form(content: dict, form: "MultiDict") -> tuple[dict, bo
     contact["about"]["title"] = form.get("contact_about_title", "").strip()
     contact["about"]["description"] = form.get("contact_about_description", "").strip()
     contact["about"]["cards"] = parse_about_cards(form)
+    return contact
 
+
+def update_store_page_from_form(content: dict, form: "MultiDict") -> dict:
+    store = content["pages"].setdefault("store", deepcopy(DEFAULT_STORE_PAGE_TEMPLATE))
+
+    hero_defaults = DEFAULT_STORE_PAGE_TEMPLATE.get("hero", {})
+    hero = store.setdefault("hero", {})
+    hero["badge"] = form.get("store_hero_badge", hero.get("badge", hero_defaults.get("badge", ""))).strip()
+    hero["title"] = form.get("store_hero_title", hero.get("title", hero_defaults.get("title", ""))).strip()
+    hero["description"] = form.get(
+        "store_hero_description",
+        hero.get("description", hero_defaults.get("description", "")),
+    ).strip()
+    hero["cta_text"] = form.get(
+        "store_hero_cta_text", hero.get("cta_text", hero_defaults.get("cta_text", ""))
+    ).strip()
+    hero["cta_link"] = form.get(
+        "store_hero_cta_link", hero.get("cta_link", hero_defaults.get("cta_link", ""))
+    ).strip()
+
+    promises_defaults = DEFAULT_STORE_PAGE_TEMPLATE.get("promises", {})
+    promises = store.setdefault("promises", {})
+    promises["title"] = form.get(
+        "store_promises_heading",
+        promises.get("title", promises_defaults.get("title", "")),
+    ).strip()
+    titles = form.getlist("store_promises_title")
+    descriptions = form.getlist("store_promises_description")
+    items: list[dict] = []
+    for title, description in zip(titles, descriptions):
+        title = title.strip()
+        description = description.strip()
+        if not any([title, description]):
+            continue
+        items.append({"title": title, "description": description})
+    if items:
+        promises["items"] = items
+    elif not promises.get("items"):
+        promises["items"] = deepcopy(promises_defaults.get("items", []))
+
+    support_defaults = DEFAULT_STORE_PAGE_TEMPLATE.get("support", {})
+    support = store.setdefault("support", {})
+    support["title"] = form.get(
+        "store_support_title", support.get("title", support_defaults.get("title", ""))
+    ).strip()
+    support["description"] = form.get(
+        "store_support_description",
+        support.get("description", support_defaults.get("description", "")),
+    ).strip()
+    support["cta_text"] = form.get(
+        "store_support_cta_text", support.get("cta_text", support_defaults.get("cta_text", ""))
+    ).strip()
+    support["cta_link"] = form.get(
+        "store_support_cta_link", support.get("cta_link", support_defaults.get("cta_link", ""))
+    ).strip()
+
+    return store
+
+
+def apply_page_update(content: dict, form: "MultiDict", page_key: str) -> dict:
+    if page_key == "home":
+        return update_home_page_from_form(content, form)
+    if page_key == "services":
+        return update_services_page_from_form(content, form)
+    if page_key == "contact":
+        return update_contact_page_from_form(content, form)
+    if page_key == "store":
+        return update_store_page_from_form(content, form)
+    raise ValueError(f"Unsupported page key: {page_key}")
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not is_admin_authenticated():
+            return redirect(url_for("admin_login", next=request.path))
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+@app.context_processor
+def inject_admin_session_state() -> dict:
+    return {"admin_authenticated": is_admin_authenticated()}
+
+
+def split_lines(value: str) -> list[str]:
+    return [line.strip() for line in value.splitlines() if line.strip()]
+
+
+def page_title(content: dict, page_key: str) -> str:
+    meta = content["pages"].get(page_key, {}).get("meta", {})
+    return meta.get("title") or content["site"].get("tagline") or content["site"]["name"]
+
+
+def compose_body_class(content: dict, *extra_classes: str) -> str:
+    ensure_content_defaults(content)
+    classes = [cls for cls in extra_classes if cls]
+    if is_admin_mode():
+        classes.extend(["admin-border", "admin-mode-active"])
+    seen: dict[str, None] = {}
+    for cls in classes:
+        if cls:
+            seen.setdefault(cls, None)
+    return " ".join(seen.keys()).strip()
+
+
+@app.route("/")
+def home():
+    content = get_request_content()
+    admin_mode = is_admin_mode()
+    uploads = list_uploads() if admin_mode else []
+    if should_use_mobile_alt(request):
+        return render_mobile_home(content)
+    return render_template(
+        "index.html",
+        content=content,
+        theme=content["site"]["colors"],
+        home=content["pages"]["home"],
+        page_title=page_title(content, "home"),
+        body_class=compose_body_class(content),
+        admin_mode=admin_mode,
+        editor_uploads=uploads,
+        page_key="home",
+    )
+
+
+@app.route("/mobile")
+def mobile_home():
+    content = get_request_content()
+    return render_mobile_home(content)
+
+
+@app.route("/services")
+def services_page():
+    content = get_request_content()
+    admin_mode = is_admin_mode()
+    uploads = list_uploads() if admin_mode else []
+    return render_template(
+        "services.html",
+        content=content,
+        theme=content["site"]["colors"],
+        services=content["pages"]["services"],
+        page_title=page_title(content, "services"),
+        body_class=compose_body_class(content),
+        admin_mode=admin_mode,
+        editor_uploads=uploads,
+        page_key="services",
+    )
+
+
+@app.route("/store")
+def store_page():
+    content = get_request_content()
+    admin_mode = is_admin_mode()
+    uploads = list_uploads() if admin_mode else []
+    inventory = load_printer_inventory()
+    printers, manufacturer_notes = flatten_printer_inventory(inventory)
+
+    per_page = 9
+    total_printers = len(printers)
+    total_pages = max(1, ceil(total_printers / per_page))
+    page_number = request.args.get("page", type=int, default=1) or 1
+    page_number = max(1, min(page_number, total_pages))
+    start = (page_number - 1) * per_page
+    end = start + per_page
+    paginated = printers[start:end]
+
+    pagination = {
+        "page": page_number,
+        "total_pages": total_pages,
+        "has_prev": page_number > 1,
+        "has_next": page_number < total_pages,
+        "prev_page": page_number - 1,
+        "next_page": page_number + 1,
+        "pages": list(range(1, total_pages + 1)),
+    }
+
+    return render_template(
+        "store.html",
+        content=content,
+        theme=content["site"]["colors"],
+        store=content["pages"]["store"],
+        printers=paginated,
+        pagination=pagination,
+        inventory_count=total_printers,
+        manufacturer_notes=manufacturer_notes,
+        page_title=page_title(content, "store"),
+        body_class=compose_body_class(content),
+        admin_mode=admin_mode,
+        editor_uploads=uploads,
+        page_key="store",
+    )
+
+
+@app.route("/contact")
+def contact_page():
+    content = get_request_content()
+    admin_mode = is_admin_mode()
+    uploads = list_uploads() if admin_mode else []
+    return render_template(
+        "contact.html",
+        content=content,
+        theme=content["site"]["colors"],
+        contact=content["pages"]["contact"],
+        page_title=page_title(content, "contact"),
+        body_class=compose_body_class(content),
+        admin_mode=admin_mode,
+        editor_uploads=uploads,
+        page_key="contact",
+    )
+
+
+@app.route("/uploads/<path:filename>")
+def uploaded_file(filename: str):
+    ensure_webroot()
+    return send_from_directory(UPLOAD_FOLDER, filename)
+
+
+@app.route("/admin/login", methods=["GET", "POST"])
+def admin_login():
+    if request.method == "GET":
+        session.pop("admin_authenticated", None)
+    if is_admin_authenticated():
+        return redirect(url_for("admin_dashboard"))
+
+    error = None
+    if request.method == "POST":
+        password = request.form.get("password", "")
+        if password == load_admin_password():
+            session["admin_authenticated"] = True
+            next_url = request.args.get("next") or url_for("admin_dashboard")
+            return redirect(next_url)
+        error = "Incorrect password."
+    content = get_request_content()
+    return render_template(
+        "login.html",
+        content=content,
+        theme=content["site"]["colors"],
+        page_title="Admin",
+        error=error,
+        body_class=compose_body_class(content),
+        admin_mode=is_admin_mode(),
+    )
+
+
+@app.route("/admin/logout")
+def admin_logout():
+    clear_draft_content()
+    session.pop("admin_authenticated", None)
+    return redirect(url_for("home"))
+
+
+@app.route("/admin", methods=["GET", "POST"])
+@login_required
+def admin_dashboard():
+    content = load_content()
+    message = session.pop("admin_message", None)
+    admin_mode_active = is_admin_mode()
+
+    if request.method == "POST":
+        action = request.form.get("action")
+        if action == "update_site_settings":
+            updated, password_changed = update_site_settings_from_form(
+                content, request.form
+            )
+            save_content(updated)
+            message_text = "Changes saved successfully."
+            if password_changed:
+                message_text += " Admin password updated."
+            session["admin_message"] = message_text
+            return redirect(url_for("admin_dashboard"))
+        if action == "upload_media":
+            file = request.files.get("media")
+            if file and file.filename:
+                filename = secure_filename(file.filename)
+                destination = UPLOAD_FOLDER / filename
+                file.save(destination)
+                session["admin_message"] = f"Uploaded {filename}."
+            else:
+                session["admin_message"] = "Please choose an image to upload."
+            return redirect(url_for("admin_dashboard"))
+
+    uploads = list_uploads()
+    password_value = load_admin_password()
+    if not password_value:
+        password_state = "empty"
+    elif password_value == DEFAULT_ADMIN_PASSWORD:
+        password_state = "default"
+    else:
+        password_state = "custom"
+    return render_template(
+        "admin.html",
+        content=content,
+        theme=content["site"]["colors"],
+        home=content["pages"]["home"],
+        services=content["pages"]["services"],
+        contact=content["pages"]["contact"],
+        page_title="Admin",
+        message=message,
+        uploads=uploads,
+        webroot_path=str(WEBROOT_PATH),
+        admin_password_state=password_state,
+        body_class=compose_body_class(content),
+        admin_mode=admin_mode_active,
+    )
+
+
+@app.route("/admin/mode", methods=["POST"])
+@login_required
+def admin_mode_toggle():
+    action = request.form.get("action")
+    next_url = safe_next_url(request.form.get("next") or request.referrer)
+    if action == "enter":
+        enter_admin_mode()
+        session["admin_message"] = "Admin mode enabled. Edit pages directly and save when finished."
+    elif action == "save_exit":
+        exit_admin_mode(save_changes=True)
+        session["admin_message"] = "Draft changes published and admin mode exited."
+    elif action == "discard_exit":
+        exit_admin_mode(save_changes=False)
+        session["admin_message"] = "Draft discarded. Admin mode exited."
+    return redirect(next_url)
+
+
+@app.route("/admin/draft/<page_key>", methods=["POST"])
+@login_required
+def update_draft(page_key: str):
+    if not is_admin_mode():
+        return jsonify({"error": "Admin mode is not active."}), 400
+
+    try:
+        content = load_draft_content()
+        apply_page_update(content, request.form, page_key)
+        save_draft_content(content)
+        page_data = content["pages"].get(page_key, {})
+        return jsonify({"page": page_data, "site": content["site"]})
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+def update_content_from_form(content: dict, form: "MultiDict") -> tuple[dict, bool]:
+    content, password_changed = update_site_settings_from_form(content, form)
+    update_home_page_from_form(content, form)
+    update_services_page_from_form(content, form)
+    update_contact_page_from_form(content, form)
+    update_store_page_from_form(content, form)
     return content, password_changed
 
 
@@ -337,8 +920,9 @@ def render_mobile_home(content: dict):
         theme=content["site"]["colors"],
         home=content["pages"]["home"],
         page_title=page_title(content, "home"),
-        body_class="mobile-alt",
+        body_class=compose_body_class(content, "mobile-alt"),
         using_mobile_alt=True,
+        admin_mode=is_admin_mode(),
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>=3.0,<4.0
+SQLAlchemy>=2.0,<3.0

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -21,6 +21,230 @@ body {
   line-height: 1.6;
 }
 
+body.admin-border {
+  box-shadow: inset 0 0 0 6px #dc2626;
+}
+
+body.admin-mode-active {
+  padding-top: 3.5rem;
+}
+
+.admin-toolbar {
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 20px 55px -35px rgba(220, 38, 38, 0.75);
+  border: 1px solid rgba(220, 38, 38, 0.4);
+  z-index: 120;
+  backdrop-filter: blur(6px);
+}
+
+.admin-toolbar__label {
+  font-weight: 600;
+  color: #b91c1c;
+  letter-spacing: 0.01em;
+}
+
+.admin-toolbar__link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.admin-toolbar__button {
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.admin-toolbar__button:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.admin-toolbar__button--primary {
+  background: var(--primary);
+  color: #ffffff;
+  box-shadow: 0 14px 35px -20px rgba(37, 99, 235, 0.75);
+}
+
+.admin-toolbar__button--ghost {
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--primary-dark);
+  border: 1px solid rgba(37, 99, 235, 0.35);
+}
+
+.page-editor {
+  position: fixed;
+  top: 4.5rem;
+  right: 1.25rem;
+  width: min(380px, 92vw);
+  max-height: calc(100vh - 6rem);
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 35px 80px -45px rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.25rem;
+  display: none;
+  z-index: 110;
+  overflow: hidden;
+}
+
+.page-editor.is-open {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 1rem;
+}
+
+.page-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.page-editor__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.page-editor__toggle {
+  border: none;
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.page-editor__body {
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.form-fields {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.form-fields label {
+  display: grid;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.form-fields input,
+.form-fields textarea,
+.form-fields select {
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(100, 116, 139, 0.28);
+  font: inherit;
+  background: #ffffff;
+  resize: vertical;
+}
+
+.form-fields textarea {
+  min-height: 90px;
+}
+
+.field-help {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.collection-wrapper {
+  border: 2px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(241, 245, 249, 0.55);
+}
+
+.collection {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.collection-item {
+  border: 1px solid rgba(100, 116, 139, 0.25);
+  border-radius: 14px;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.6rem;
+  background: #ffffff;
+}
+
+.collection-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  gap: 0.5rem;
+}
+
+.collection-item button.remove-item {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.add-item {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid rgba(37, 99, 235, 0.45);
+  border-radius: 999px;
+  padding: 0.3rem 0.9rem 0.3rem 0.55rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.add-item::before {
+  content: '+';
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+
+.editor-hint {
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: rgba(226, 232, 240, 0.4);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -124,6 +348,38 @@ nav a:hover {
   box-shadow: 0 18px 35px -20px color-mix(in srgb, var(--primary) 80%, transparent);
 }
 
+.ghost-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, rgba(148, 163, 184, 0.4));
+  background: transparent;
+  color: var(--primary-dark);
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.ghost-button:hover:not(.disabled) {
+  background: color-mix(in srgb, var(--primary) 12%, rgba(255, 255, 255, 0.8));
+  transform: translateY(-1px);
+}
+
+.ghost-button.active {
+  background: var(--primary);
+  color: var(--white);
+  border-color: transparent;
+}
+
+.ghost-button.disabled,
+.ghost-button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .section {
   padding: 4rem 1.5rem;
 }
@@ -152,6 +408,285 @@ nav a:hover {
 
 .hero-content {
   align-items: center;
+}
+
+.store-hero {
+  position: relative;
+  overflow: hidden;
+}
+
+.store-hero__content {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.store-hero__copy .badge {
+  margin-bottom: 1rem;
+}
+
+.store-hero__copy .primary-button {
+  margin-top: 1.5rem;
+}
+
+.store-hero__stats {
+  display: grid;
+  gap: 1rem;
+  background: var(--white);
+  padding: 1.8rem;
+  border-radius: 24px;
+  box-shadow: 0 20px 45px -30px rgba(15, 23, 42, 0.35);
+  align-self: stretch;
+}
+
+.store-hero__stat {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.store-hero__stat strong {
+  font-size: 2.4rem;
+  color: var(--primary-dark);
+  line-height: 1.1;
+}
+
+.store-hero__stat span {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.store-promises__items {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.store-promise {
+  background: var(--white);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 20px 45px -35px rgba(15, 23, 42, 0.25);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.store-promise h3 {
+  color: var(--primary-dark);
+  font-size: 1.2rem;
+}
+
+.store-promise p {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.store-grid__intro {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.store-grid__intro h2 {
+  text-align: left;
+  margin-bottom: 0.75rem;
+}
+
+.store-grid__intro p {
+  max-width: 640px;
+  color: var(--muted);
+}
+
+.store-grid__meta {
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+
+.store-grid__items {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.product-card {
+  background: var(--white);
+  border-radius: 26px;
+  overflow: hidden;
+  box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.product-card__media {
+  background: color-mix(in srgb, var(--primary) 12%, rgba(255, 255, 255, 0.85));
+  aspect-ratio: 4 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.product-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.product-card__body {
+  display: grid;
+  gap: 1.1rem;
+  padding: 1.75rem;
+}
+
+.product-card__manufacturer {
+  font-weight: 600;
+  color: var(--primary);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+}
+
+.product-card__meta {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.product-card__meta li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+
+.product-card__meta span {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.product-card__toner {
+  background: rgba(148, 163, 184, 0.12);
+  padding: 1.2rem;
+  border-radius: 18px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.product-card__toner h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--primary-dark);
+}
+
+.product-card__toner ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.product-card__toner li {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.product-card__toner-name {
+  font-weight: 600;
+}
+
+.product-card__toner-sku {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.product-card__toner-yield {
+  font-size: 0.85rem;
+  color: var(--primary-dark);
+}
+
+.product-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.product-card__actions .primary-button,
+.product-card__actions .ghost-button {
+  flex: 1 1 160px;
+  justify-content: center;
+}
+
+.store-grid__empty {
+  text-align: center;
+  padding: 3rem;
+  border-radius: 20px;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+}
+
+.store-grid__pagination ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.store-grid__pagination .ghost-button {
+  min-width: 48px;
+  justify-content: center;
+}
+
+.store-support {
+  background: linear-gradient(
+    140deg,
+    color-mix(in srgb, var(--primary) 15%, transparent),
+    color-mix(in srgb, var(--primary) 6%, transparent)
+  );
+}
+
+.store-support__card {
+  background: var(--white);
+  border-radius: 28px;
+  padding: 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 25px 60px -40px rgba(15, 23, 42, 0.45);
+}
+
+.store-support__card p {
+  max-width: 540px;
+  color: var(--muted);
+  margin-top: 0.75rem;
+}
+
+.store-notes__grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.store-note {
+  padding: 1.8rem;
+  border-radius: 20px;
+  background: var(--white);
+  box-shadow: 0 18px 45px -35px rgba(15, 23, 42, 0.35);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.store-note h3 {
+  color: var(--primary-dark);
+  margin: 0;
+}
+
+.store-note p {
+  color: var(--muted);
+  margin: 0;
 }
 
 .hero-image {
@@ -379,5 +914,23 @@ ul.checklist li::before {
   nav ul {
     flex-wrap: wrap;
     justify-content: center;
+  }
+
+  .store-support__card {
+    text-align: center;
+    justify-content: center;
+  }
+
+  .store-support__card .primary-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .product-card__actions {
+    flex-direction: column;
+  }
+
+  .store-hero__stats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 }

--- a/static/img/printers/canon-imageclass-lbp226dw.svg
+++ b/static/img/printers/canon-imageclass-lbp226dw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">imageCLASS LBP226dw illustration</title>
+  <desc id="desc">Stylized illustration of the imageCLASS LBP226dw laser printer from Canon.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ef4444" />
+      <stop offset="100%" stop-color="#991b1b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#ef4444" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Canon</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">imageCLASS LBP226dw</text>
+</svg>

--- a/static/img/printers/canon-imageclass-lbp6230dw.svg
+++ b/static/img/printers/canon-imageclass-lbp6230dw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">imageCLASS LBP6230dw illustration</title>
+  <desc id="desc">Stylized illustration of the imageCLASS LBP6230dw laser printer from Canon.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ef4444" />
+      <stop offset="100%" stop-color="#991b1b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#ef4444" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Canon</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">imageCLASS LBP6230dw</text>
+</svg>

--- a/static/img/printers/canon-imageclass-mf269dw-ii.svg
+++ b/static/img/printers/canon-imageclass-mf269dw-ii.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">imageCLASS MF269dw II illustration</title>
+  <desc id="desc">Stylized illustration of the imageCLASS MF269dw II laser printer from Canon.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ef4444" />
+      <stop offset="100%" stop-color="#991b1b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#ef4444" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Canon</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">imageCLASS MF269dw II</text>
+</svg>

--- a/static/img/printers/canon-imageclass-mf445dw.svg
+++ b/static/img/printers/canon-imageclass-mf445dw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">imageCLASS MF445dw illustration</title>
+  <desc id="desc">Stylized illustration of the imageCLASS MF445dw laser printer from Canon.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ef4444" />
+      <stop offset="100%" stop-color="#991b1b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#ef4444" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Canon</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">imageCLASS MF445dw</text>
+</svg>

--- a/static/img/printers/hp-color-laserjet-pro-m454dw.svg
+++ b/static/img/printers/hp-color-laserjet-pro-m454dw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">Color LaserJet Pro M454dw illustration</title>
+  <desc id="desc">Stylized illustration of the Color LaserJet Pro M454dw laser printer from HP.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#1e3a8a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#1d4ed8" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">HP</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">Color LaserJet Pro M454dw</text>
+</svg>

--- a/static/img/printers/hp-laserjet-enterprise-m507dn.svg
+++ b/static/img/printers/hp-laserjet-enterprise-m507dn.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">LaserJet Enterprise M507dn illustration</title>
+  <desc id="desc">Stylized illustration of the LaserJet Enterprise M507dn laser printer from HP.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#1e3a8a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#1d4ed8" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">HP</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">LaserJet Enterprise M507dn</text>
+</svg>

--- a/static/img/printers/hp-laserjet-pro-m203dw.svg
+++ b/static/img/printers/hp-laserjet-pro-m203dw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">LaserJet Pro M203dw illustration</title>
+  <desc id="desc">Stylized illustration of the LaserJet Pro M203dw laser printer from HP.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#1e3a8a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#1d4ed8" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">HP</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">LaserJet Pro M203dw</text>
+</svg>

--- a/static/img/printers/hp-laserjet-pro-m404n.svg
+++ b/static/img/printers/hp-laserjet-pro-m404n.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">LaserJet Pro M404n illustration</title>
+  <desc id="desc">Stylized illustration of the LaserJet Pro M404n laser printer from HP.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#1e3a8a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#1d4ed8" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">HP</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">LaserJet Pro M404n</text>
+</svg>

--- a/static/img/printers/kyocera-ecosys-m5526cdw.svg
+++ b/static/img/printers/kyocera-ecosys-m5526cdw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">ECOSYS M5526cdw illustration</title>
+  <desc id="desc">Stylized illustration of the ECOSYS M5526cdw laser printer from Kyocera.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="100%" stop-color="#064e3b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#0f766e" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Kyocera</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">ECOSYS M5526cdw</text>
+</svg>

--- a/static/img/printers/kyocera-ecosys-p2040dw.svg
+++ b/static/img/printers/kyocera-ecosys-p2040dw.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">ECOSYS P2040dw illustration</title>
+  <desc id="desc">Stylized illustration of the ECOSYS P2040dw laser printer from Kyocera.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="100%" stop-color="#064e3b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#0f766e" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Kyocera</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">ECOSYS P2040dw</text>
+</svg>

--- a/static/img/printers/kyocera-ecosys-p3155dn.svg
+++ b/static/img/printers/kyocera-ecosys-p3155dn.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">ECOSYS P3155dn illustration</title>
+  <desc id="desc">Stylized illustration of the ECOSYS P3155dn laser printer from Kyocera.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="100%" stop-color="#064e3b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#0f766e" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Kyocera</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">ECOSYS P3155dn</text>
+</svg>

--- a/static/img/printers/kyocera-ecosys-p6235cdn.svg
+++ b/static/img/printers/kyocera-ecosys-p6235cdn.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">ECOSYS P6235cdn illustration</title>
+  <desc id="desc">Stylized illustration of the ECOSYS P6235cdn laser printer from Kyocera.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="100%" stop-color="#064e3b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#0f766e" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Kyocera</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">ECOSYS P6235cdn</text>
+</svg>

--- a/static/img/printers/toshiba-e-studio-2515ac.svg
+++ b/static/img/printers/toshiba-e-studio-2515ac.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">e-STUDIO 2515AC illustration</title>
+  <desc id="desc">Stylized illustration of the e-STUDIO 2515AC laser printer from Toshiba.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9333ea" />
+      <stop offset="100%" stop-color="#5b21b6" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#9333ea" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Toshiba</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">e-STUDIO 2515AC</text>
+</svg>

--- a/static/img/printers/toshiba-e-studio-330ac.svg
+++ b/static/img/printers/toshiba-e-studio-330ac.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">e-STUDIO 330AC illustration</title>
+  <desc id="desc">Stylized illustration of the e-STUDIO 330AC laser printer from Toshiba.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9333ea" />
+      <stop offset="100%" stop-color="#5b21b6" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#9333ea" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Toshiba</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">e-STUDIO 330AC</text>
+</svg>

--- a/static/img/printers/toshiba-e-studio-409p.svg
+++ b/static/img/printers/toshiba-e-studio-409p.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">e-STUDIO 409p illustration</title>
+  <desc id="desc">Stylized illustration of the e-STUDIO 409p laser printer from Toshiba.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9333ea" />
+      <stop offset="100%" stop-color="#5b21b6" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#9333ea" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Toshiba</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">e-STUDIO 409p</text>
+</svg>

--- a/static/img/printers/toshiba-e-studio-409s.svg
+++ b/static/img/printers/toshiba-e-studio-409s.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">e-STUDIO 409s illustration</title>
+  <desc id="desc">Stylized illustration of the e-STUDIO 409s laser printer from Toshiba.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9333ea" />
+      <stop offset="100%" stop-color="#5b21b6" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#grad)" rx="32" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="60" width="400" height="180" rx="28" fill="#f8fafc" opacity="0.94" />
+    <rect x="20" y="80" width="360" height="80" rx="12" fill="#e2e8f0" />
+    <rect x="120" y="0" width="160" height="80" rx="14" fill="#1f2937" opacity="0.9" />
+    <rect x="70" y="180" width="260" height="36" rx="12" fill="#cbd5f5" opacity="0.9" />
+    <circle cx="320" cy="190" r="12" fill="#9333ea" opacity="0.8" />
+  </g>
+  <text x="320" y="360" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="36" fill="#f8fafc" font-weight="600">Toshiba</text>
+  <text x="320" y="404" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#f8fafc">e-STUDIO 409s</text>
+</svg>

--- a/static/js/admin-mode.js
+++ b/static/js/admin-mode.js
@@ -1,0 +1,372 @@
+(function () {
+  const body = document.body;
+  if (!body || body.dataset.adminMode !== '1') {
+    return;
+  }
+
+  const pageKey = body.dataset.pageKey;
+  const editor = document.querySelector('.page-editor[data-page-editor]');
+  const form = editor ? editor.querySelector('[data-editor-form]') : null;
+
+  if (!pageKey || !editor || !form) {
+    return;
+  }
+
+  const debounce = (fn, delay = 250) => {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), delay);
+    };
+  };
+
+  const renderers = {
+    home: renderHome,
+    services: renderServices,
+    contact: renderContact,
+    store: renderStore,
+  };
+
+  const render = renderers[pageKey];
+  if (!render) {
+    return;
+  }
+
+  const toggleButton = editor.querySelector('[data-editor-toggle]');
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      const isOpen = editor.classList.toggle('is-open');
+      toggleButton.textContent = isOpen ? 'Hide editor' : 'Show editor';
+    });
+  }
+
+  enhanceCollections(form);
+
+  const submitDraft = debounce(() => {
+    const formData = new FormData(form);
+    fetch(`/admin/draft/${pageKey}` , {
+      method: 'POST',
+      body: formData,
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (!data || data.error) {
+          console.error(data ? data.error : 'Unknown error updating draft');
+          return;
+        }
+        render(data.page || {}, data.site || {});
+      })
+      .catch((error) => {
+        console.error('Error updating draft', error);
+      });
+  }, 250);
+
+  form.addEventListener('input', submitDraft);
+  form.addEventListener('change', submitDraft);
+  form.addEventListener('submit', (event) => event.preventDefault());
+
+  function enhanceCollections(scope) {
+    scope.querySelectorAll('.add-item').forEach((button) => {
+      button.addEventListener('click', () => {
+        const templateId = button.dataset.template;
+        const template = templateId ? document.getElementById(templateId) : null;
+        if (!template || !template.content.firstElementChild) {
+          return;
+        }
+        const clone = template.content.firstElementChild.cloneNode(true);
+        const collection = button.closest('.collection-wrapper')?.querySelector('.collection');
+        if (!collection) {
+          return;
+        }
+        collection.appendChild(clone);
+        attachRemoveHandlers(clone);
+        submitDraft();
+      });
+    });
+
+    attachRemoveHandlers(scope);
+  }
+
+  function attachRemoveHandlers(scope) {
+    scope.querySelectorAll('.remove-item').forEach((button) => {
+      if (button.dataset.bound === '1') {
+        return;
+      }
+      button.dataset.bound = '1';
+      button.addEventListener('click', () => {
+        const item = button.closest('.collection-item');
+        item?.remove();
+        submitDraft();
+      });
+    });
+  }
+
+  function setText(selector, value) {
+    const element = document.querySelector(selector);
+    if (!element) {
+      return;
+    }
+    element.textContent = value || '';
+  }
+
+  function setLink(selector, text, href) {
+    const element = document.querySelector(selector);
+    if (!element) {
+      return;
+    }
+    element.textContent = text || '';
+    if (href) {
+      element.setAttribute('href', href);
+    } else {
+      element.removeAttribute('href');
+    }
+  }
+
+  function renderImage(container, src, alt) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    if (src) {
+      container.hidden = false;
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = alt || '';
+      img.loading = 'lazy';
+      container.appendChild(img);
+    } else {
+      container.hidden = true;
+    }
+  }
+
+  function renderList(containerSelector, templateId, items, configure) {
+    const container = typeof containerSelector === 'string'
+      ? document.querySelector(containerSelector)
+      : containerSelector;
+    const template = templateId ? document.getElementById(templateId) : null;
+    if (!container || !template || !template.content.firstElementChild) {
+      return;
+    }
+    container.innerHTML = '';
+    (items || []).forEach((item) => {
+      const node = template.content.firstElementChild.cloneNode(true);
+      configure(node, item);
+      container.appendChild(node);
+    });
+  }
+
+  function renderHome(page) {
+    const hero = page.hero || {};
+    setText('[data-slot="home.hero.badge"]', hero.badge);
+    setText('[data-slot="home.hero.title"]', hero.title);
+    setText('[data-slot="home.hero.description"]', hero.description);
+    setLink('[data-slot-link="home.hero.cta"]', hero.cta_text, hero.cta_link || '#');
+    renderImage(document.querySelector('[data-slot-container="home.hero.image"]'), hero.image, hero.image_alt);
+
+    const whatWePrint = page.what_we_print || {};
+    setText('[data-slot="home.what_we_print.title"]', whatWePrint.title);
+    renderList('[data-repeat="home.what_we_print.items"]', 'tpl-home-what-we-print', whatWePrint.items || [], (node, item) => {
+      const cardImage = node.querySelector('[data-image-container]');
+      renderImage(cardImage, item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+      const list = node.querySelector('[data-list]');
+      if (list) {
+        list.innerHTML = '';
+        if (item.bullets && item.bullets.length) {
+          list.hidden = false;
+          item.bullets.forEach((bullet) => {
+            const li = document.createElement('li');
+            li.textContent = bullet;
+            list.appendChild(li);
+          });
+        } else {
+          list.hidden = true;
+        }
+      }
+    });
+
+    const whyChoose = page.why_choose || {};
+    setText('[data-slot="home.why_choose.title"]', whyChoose.title);
+    renderList('[data-repeat="home.why_choose.items"]', 'tpl-home-why-choose', whyChoose.items || [], (node, item) => {
+      const cardImage = node.querySelector('[data-image-container]');
+      renderImage(cardImage, item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+    });
+
+    const testimonials = page.testimonials || {};
+    setText('[data-slot="home.testimonials.title"]', testimonials.title);
+    renderList('[data-repeat="home.testimonials.items"]', 'tpl-home-testimonial', testimonials.items || [], (node, item) => {
+      const quote = node.querySelector('p');
+      const cite = node.querySelector('cite');
+      if (quote) quote.textContent = item.quote || '';
+      if (cite) cite.textContent = item.author || '';
+    });
+  }
+
+  function renderServices(page) {
+    const hero = page.hero || {};
+    setText('[data-slot="services.hero.badge"]', hero.badge);
+    setText('[data-slot="services.hero.title"]', hero.title);
+    setText('[data-slot="services.hero.description"]', hero.description);
+
+    const capabilities = page.capabilities || {};
+    setText('[data-slot="services.capabilities.title"]', capabilities.title);
+    renderList('[data-repeat="services.capabilities.items"]', 'tpl-services-capability', capabilities.items || [], (node, item) => {
+      renderImage(node.querySelector('[data-image-container]'), item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+      const list = node.querySelector('[data-list]');
+      if (list) {
+        list.innerHTML = '';
+        if (item.bullets && item.bullets.length) {
+          list.hidden = false;
+          item.bullets.forEach((bullet) => {
+            const li = document.createElement('li');
+            li.textContent = bullet;
+            list.appendChild(li);
+          });
+        } else {
+          list.hidden = true;
+        }
+      }
+    });
+
+    const bundles = page.bundles || {};
+    setText('[data-slot="services.bundles.title"]', bundles.title);
+    renderList('[data-repeat="services.bundles.items"]', 'tpl-services-bundle', bundles.items || [], (node, item) => {
+      renderImage(node.querySelector('[data-image-container]'), item.image, item.image_alt);
+      const title = node.querySelector('h3');
+      const price = node.querySelector('.price');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (price) price.textContent = item.price || '';
+      if (description) description.textContent = item.description || '';
+      const list = node.querySelector('[data-list]');
+      if (list) {
+        list.innerHTML = '';
+        if (item.bullets && item.bullets.length) {
+          list.hidden = false;
+          item.bullets.forEach((bullet) => {
+            const li = document.createElement('li');
+            li.textContent = bullet;
+            list.appendChild(li);
+          });
+        } else {
+          list.hidden = true;
+        }
+      }
+    });
+
+    const process = page.process || {};
+    setText('[data-slot="services.process.title"]', process.title);
+    renderList('[data-repeat="services.process.steps"]', 'tpl-services-step', process.steps || [], (node, item) => {
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+    });
+    const cta = process.cta || {};
+    setText('[data-slot="services.process.cta.title"]', cta.title);
+    setText('[data-slot="services.process.cta.description"]', cta.description);
+    setLink('[data-slot-link="services.process.cta"]', cta.text, cta.link || '#');
+  }
+
+  function renderContact(page) {
+    const hero = page.hero || {};
+    setText('[data-slot="contact.hero.badge"]', hero.badge);
+    setText('[data-slot="contact.hero.title"]', hero.title);
+    setText('[data-slot="contact.hero.description"]', hero.description);
+
+    const studio = page.studio || {};
+    setText('[data-slot="contact.studio.visit_title"]', studio.visit_title);
+    renderSimpleList('[data-list="contact.studio.address"]', studio.address || []);
+    setText('[data-slot="contact.studio.hours_title"]', studio.hours_title);
+    renderSimpleList('[data-list="contact.studio.hours"]', studio.hours || []);
+    setLink('[data-slot-link="contact.studio.phone"]', studio.phone, studio.phone_href ? `tel:${studio.phone_href}` : '');
+    setLink('[data-slot-link="contact.studio.email"]', studio.email, studio.email ? `mailto:${studio.email}` : '');
+    setText('[data-slot="contact.studio.phone_title"]', studio.phone_title);
+    setText('[data-slot="contact.studio.email_title"]', studio.email_title);
+
+    const formData = page.form || {};
+    setText('[data-slot="contact.form.title"]', formData.title);
+    const formContainer = document.querySelector('[data-repeat="contact.form.fields"]');
+    const formTemplate = document.getElementById('tpl-contact-form-field');
+    if (formContainer && formTemplate && formTemplate.content.firstElementChild) {
+      formContainer.innerHTML = '';
+      (formData.fields || []).forEach((field) => {
+        const node = formTemplate.content.firstElementChild.cloneNode(true);
+        const label = node.querySelector('.field-label');
+        const input = node.querySelector('input, textarea');
+        if (label) label.textContent = field.label || '';
+        if (input) {
+          if (field.type === 'textarea') {
+            const textarea = document.createElement('textarea');
+            textarea.placeholder = field.placeholder || '';
+            textarea.name = field.name || '';
+            node.replaceChild(textarea, input);
+          } else {
+            input.type = field.type || 'text';
+            input.placeholder = field.placeholder || '';
+            input.name = field.name || '';
+          }
+        }
+        formContainer.appendChild(node);
+      });
+    }
+    setText('[data-slot="contact.form.submit_text"]', formData.submit_text);
+
+    const about = page.about || {};
+    setText('[data-slot="contact.about.title"]', about.title);
+    setText('[data-slot="contact.about.description"]', about.description);
+    renderList('[data-repeat="contact.about.cards"]', 'tpl-contact-about-card', about.cards || [], (node, item) => {
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+    });
+  }
+
+  function renderStore(page) {
+    const hero = page.hero || {};
+    setText('[data-slot="store.hero.badge"]', hero.badge);
+    setText('[data-slot="store.hero.title"]', hero.title);
+    setText('[data-slot="store.hero.description"]', hero.description);
+    setLink('[data-slot-link="store.hero.cta"]', hero.cta_text, hero.cta_link || '#');
+
+    const promises = page.promises || {};
+    setText('[data-slot="store.promises.title"]', promises.title);
+    renderList('[data-repeat="store.promises.items"]', 'tpl-store-promise', promises.items || [], (node, item) => {
+      const title = node.querySelector('h3');
+      const description = node.querySelector('p');
+      if (title) title.textContent = item.title || '';
+      if (description) description.textContent = item.description || '';
+    });
+
+    const support = page.support || {};
+    setText('[data-slot="store.support.title"]', support.title);
+    setText('[data-slot="store.support.description"]', support.description);
+    setLink('[data-slot-link="store.support.cta"]', support.cta_text, support.cta_link || '#');
+  }
+
+  function renderSimpleList(selector, items) {
+    const container = document.querySelector(selector);
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    (items || []).forEach((item) => {
+      const div = document.createElement('div');
+      div.textContent = item;
+      container.appendChild(div);
+    });
+  }
+})();

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -2,480 +2,247 @@
 {% block extra_head %}
   <style>
     .admin-dashboard {
-      max-width: 1200px;
+      max-width: 1080px;
       margin: 0 auto;
-      padding: 2rem 1.5rem 4rem;
-      display: grid;
-      gap: 2.5rem;
-    }
-
-    .admin-dashboard h1 {
-      margin-bottom: 0.5rem;
-    }
-
-    .admin-intro {
-      display: grid;
-      gap: 0.75rem;
-    }
-
-    .admin-sections {
+      padding: 2.5rem 1.5rem 4rem;
       display: grid;
       gap: 2rem;
     }
 
+    .admin-header {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .admin-header h1 {
+      margin: 0;
+      font-size: clamp(2rem, 3vw, 2.6rem);
+    }
+
+    .admin-header p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 720px;
+    }
+
+    .alert {
+      background: rgba(34, 197, 94, 0.12);
+      border: 1px solid rgba(34, 197, 94, 0.25);
+      color: #166534;
+      padding: 0.9rem 1.1rem;
+      border-radius: 14px;
+      font-weight: 600;
+    }
+
     .section-card {
       background: #ffffff;
-      border-radius: 20px;
-      padding: 1.75rem;
-      box-shadow: 0 25px 65px -45px rgba(15, 23, 42, 0.45);
+      border-radius: 22px;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      box-shadow: 0 32px 70px -55px rgba(15, 23, 42, 0.6);
+      padding: 1.8rem;
       display: grid;
       gap: 1.5rem;
     }
 
-    .section-card[data-section] {
-      border: 1px solid rgba(148, 163, 184, 0.18);
-    }
-
-    .section-toolbar {
+    .section-card header {
       display: flex;
+      align-items: center;
       justify-content: space-between;
-      align-items: flex-start;
-      gap: 1.5rem;
+      gap: 1rem;
     }
 
-    .section-toolbar h2 {
+    .section-card header h2 {
       margin: 0;
-      font-size: 1.3rem;
+      font-size: 1.35rem;
       color: var(--primary-dark);
     }
 
-    .section-toolbar p {
-      margin: 0.35rem 0 0;
+    .mode-status {
+      font-weight: 600;
+      margin: 0;
+    }
+
+    .mode-status.is-active {
+      color: #b91c1c;
+    }
+
+    .mode-actions {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .mode-actions p {
+      margin: 0;
       color: var(--muted);
     }
 
-    .edit-toggle {
+    .mode-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .mode-buttons form {
+      display: inline-flex;
+    }
+
+    .ghost-button {
+      border: 1px solid rgba(37, 99, 235, 0.35);
       border-radius: 999px;
-      border: 1px solid rgba(148, 163, 184, 0.55);
+      padding: 0.55rem 1.4rem;
+      font-weight: 600;
       background: #ffffff;
       color: var(--primary-dark);
-      padding: 0.35rem 1rem;
-      font-weight: 600;
       cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-      transition: all 0.2s ease-in-out;
     }
 
-    .edit-toggle::before {
-      content: '\270E';
-      font-size: 0.9rem;
-    }
-
-    .section-card.is-editing .edit-toggle {
-      background: var(--primary);
-      border-color: transparent;
-      color: #ffffff;
-      box-shadow: 0 12px 20px -12px rgba(37, 99, 235, 0.7);
-    }
-
-    .section-card.is-editing .edit-toggle::before {
-      content: '\2713';
-    }
-
-    .section-preview {
-      border: 2px dashed rgba(148, 163, 184, 0.25);
-      border-radius: 16px;
-      padding: 1rem 1.25rem;
-      background: rgba(241, 245, 249, 0.6);
+    .form-grid {
       display: grid;
-      gap: 1rem;
-      transition: all 0.2s ease-in-out;
+      gap: 1.25rem;
     }
 
-    .section-card.is-editing .section-preview {
-      border-color: rgba(37, 99, 235, 0.45);
-      background: rgba(59, 130, 246, 0.08);
-    }
-
-    .preview-grid {
-      display: grid;
-      gap: 0.75rem;
-    }
-
-    .preview-grid dl {
-      margin: 0;
-      display: grid;
-      gap: 0.15rem;
-    }
-
-    .preview-grid dt {
-      font-weight: 600;
-      font-size: 0.85rem;
-      letter-spacing: 0.02em;
-      text-transform: uppercase;
-      color: var(--muted);
-    }
-
-    .preview-grid dd {
-      margin: 0;
-    }
-
-    .preview-list {
-      margin: 0;
-      padding-left: 1rem;
-      color: var(--primary-dark);
-      display: grid;
-      gap: 0.25rem;
-    }
-
-    .color-swatches {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: 0.75rem;
-    }
-
-    .color-swatch {
-      display: grid;
-      gap: 0.35rem;
-      font-size: 0.9rem;
-    }
-
-    .color-swatch .swatch-label {
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      font-weight: 600;
-      font-size: 0.75rem;
-      color: var(--muted);
-    }
-
-    .color-swatch .swatch-color {
-      border-radius: 12px;
-      height: 36px;
-      border: 1px solid rgba(15, 23, 42, 0.08);
-    }
-
-    .color-swatch .swatch-value {
-      font-family: 'JetBrains Mono', monospace;
-      font-size: 0.85rem;
-    }
-
-    .field-help {
-      display: block;
-      margin-top: 0.35rem;
-      font-size: 0.8rem;
-      color: var(--muted);
-    }
-
-    .section-body {
-      display: none;
-      gap: 1.5rem;
-    }
-
-    .section-card.is-editing .section-body {
-      display: grid;
-    }
-
-    .form-fields {
+    .form-row {
       display: grid;
       gap: 1rem;
     }
 
-    .form-fields label {
+    .form-row.two-column {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .form-field {
       display: grid;
       gap: 0.4rem;
       font-weight: 600;
     }
 
-    .form-fields input,
-    .form-fields textarea,
-    .form-fields select {
+    .form-field input,
+    .form-field textarea,
+    .form-field select {
       padding: 0.75rem 1rem;
       border-radius: 12px;
-      border: 1px solid rgba(100, 116, 139, 0.25);
+      border: 1px solid rgba(148, 163, 184, 0.35);
       font: inherit;
+      background: #ffffff;
+    }
+
+    .form-field textarea {
+      min-height: 110px;
       resize: vertical;
-      background: #ffffff;
     }
 
-    .form-fields textarea {
-      min-height: 120px;
-    }
-
-    .collection-wrapper {
-      position: relative;
-      border: 2px dashed rgba(148, 163, 184, 0.35);
-      border-radius: 18px;
-      padding: 1rem;
+    .color-grid {
       display: grid;
       gap: 1rem;
-      background: rgba(248, 250, 252, 0.55);
-      transition: all 0.2s ease-in-out;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     }
 
-    .collection-wrapper:hover {
-      border-color: rgba(37, 99, 235, 0.6);
-      background: rgba(59, 130, 246, 0.08);
-    }
-
-    .collection {
+    .color-grid label {
       display: grid;
-      gap: 1rem;
-    }
-
-    .collection-item {
-      border: 1px solid rgba(100, 116, 139, 0.25);
-      border-radius: 16px;
-      padding: 1rem;
-      display: grid;
-      gap: 0.75rem;
-      background: #ffffff;
-      box-shadow: 0 18px 40px -38px rgba(15, 23, 42, 0.6);
-    }
-
-    .collection-item-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
+      gap: 0.35rem;
       font-weight: 600;
-    }
-
-    .collection-item button.remove-item {
-      background: none;
-      border: none;
-      color: var(--muted);
-      cursor: pointer;
       font-size: 0.9rem;
-    }
-
-    .add-item {
-      justify-self: center;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      border: 1px solid rgba(37, 99, 235, 0.45);
-      border-radius: 999px;
-      padding: 0.35rem 1.1rem 0.35rem 0.6rem;
-      font-weight: 600;
-      color: var(--primary-dark);
-      background: #ffffff;
-      cursor: pointer;
-      transition: all 0.2s ease-in-out;
-      opacity: 0;
-      transform: translateY(-8px);
-    }
-
-    .add-item::before {
-      content: '+';
-      width: 1.75rem;
-      height: 1.75rem;
-      border-radius: 999px;
-      background: var(--primary);
-      color: #ffffff;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.1rem;
-    }
-
-    .collection-wrapper:hover .add-item,
-    .section-card.is-editing .collection-wrapper .add-item {
-      opacity: 1;
-      transform: translateY(0);
-    }
-
-    .admin-actions {
-      display: flex;
-      justify-content: flex-end;
-      padding-top: 0.5rem;
-    }
-
-    .admin-actions button {
-      padding-inline: 2.5rem;
-    }
-
-    .alert {
-      background: rgba(34, 197, 94, 0.12);
-      color: #15803d;
-      padding: 0.85rem 1rem;
-      border-radius: 12px;
-      font-weight: 600;
-    }
-
-    .image-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 1rem;
-    }
-
-    .image-grid figure {
-      border: 1px solid rgba(100, 116, 139, 0.2);
-      border-radius: 14px;
-      padding: 1rem;
-      background: #ffffff;
-      display: grid;
-      gap: 0.5rem;
-      justify-items: center;
-    }
-
-    .image-grid img {
-      max-width: 100%;
-      border-radius: 8px;
-    }
-
-    .color-inputs {
-      display: grid;
-      gap: 0.75rem;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-
-    .color-inputs label {
-      align-items: center;
-      grid-template-columns: 1fr auto;
-    }
-
-    .color-inputs input[type='color'] {
-      width: 52px;
-      height: 36px;
-      padding: 0;
-      border: none;
-      background: none;
     }
 
     .file-note {
-      font-size: 0.9rem;
+      font-size: 0.85rem;
       color: var(--muted);
     }
 
-    @media (max-width: 720px) {
-      .section-toolbar {
-        flex-direction: column;
-        align-items: stretch;
+    @media (max-width: 768px) {
+      .admin-toolbar {
+        inset: auto 1rem 1rem 1rem;
       }
 
-      .edit-toggle {
-        justify-content: center;
-      }
-
-      .section-preview {
-        padding: 1rem;
+      body.admin-mode-active {
+        padding-top: 5rem;
       }
     }
   </style>
 {% endblock %}
 {% block content %}
   <section class="admin-dashboard">
-    <div class="admin-intro">
-      <h1>Content management</h1>
-      <p>Hover a section to reveal quick add controls and click <strong>Edit section</strong> to update copy, colors, and lists. Changes are saved to <code>{{ webroot_path }}/content.json</code>.</p>
+    <div class="admin-header">
+      <h1>Site settings</h1>
+      <p>
+        Manage the global configuration for your print studio. Use the admin mode toggle to edit
+        page content directly while previewing updates in real time.
+      </p>
       {% if message %}
         <div class="alert">{{ message }}</div>
       {% endif %}
     </div>
 
-    <form method="post" class="admin-sections">
-      <input type="hidden" name="action" value="update_content" />
-      <datalist id="media-options">
-        <option value=""></option>
-        {% for upload in uploads %}
-          <option value="/uploads/{{ upload }}">/uploads/{{ upload }}</option>
-        {% endfor %}
-      </datalist>
+    <article class="section-card">
+      <header>
+        <h2>Admin mode</h2>
+      </header>
+      <div class="mode-actions">
+        {% if admin_mode %}
+          <p class="mode-status is-active">Admin mode is currently active.</p>
+          <p>Browse the public pages to edit content. Save or discard your draft when you are ready.</p>
+          <div class="mode-buttons">
+            <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+              <input type="hidden" name="action" value="save_exit" />
+              <input type="hidden" name="next" value="{{ request.path }}" />
+              <button class="primary-button" type="submit">Save &amp; exit</button>
+            </form>
+            <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+              <input type="hidden" name="action" value="discard_exit" />
+              <input type="hidden" name="next" value="{{ request.path }}" />
+              <button class="ghost-button" type="submit">Discard draft</button>
+            </form>
+          </div>
+        {% else %}
+          <p class="mode-status">Admin mode is off.</p>
+          <p>Turn it on to open the inline editors on each page and preview updates before publishing.</p>
+          <div class="mode-buttons">
+            <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+              <input type="hidden" name="action" value="enter" />
+              <input type="hidden" name="next" value="{{ url_for('home') }}" />
+              <button class="primary-button" type="submit">Enter admin mode</button>
+            </form>
+          </div>
+        {% endif %}
+      </div>
+    </article>
 
-      <article class="section-card is-editing" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Admin access</h2>
-            <p>Manage the password required to sign in</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="true">Done</button>
+    <form method="post" class="section-card">
+      <header>
+        <h2>Branding &amp; theme</h2>
+      </header>
+      <input type="hidden" name="action" value="update_site_settings" />
+      <div class="form-grid">
+        <div class="form-row two-column">
+          <label class="form-field">
+            Business name
+            <input type="text" name="site_name" value="{{ content.site.name }}" required />
+          </label>
+          <label class="form-field">
+            Tagline
+            <input type="text" name="site_tagline" value="{{ content.site.tagline }}" />
+          </label>
         </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Password status</dt>
-              <dd>
-                {% if admin_password_state == 'custom' %}
-                  Custom password set
-                {% elif admin_password_state == 'empty' %}
-                  Password cleared (no password required)
-                {% else %}
-                  Using default password
-                {% endif %}
-              </dd>
-            </dl>
-          </div>
+        <div class="form-row">
+          <label class="form-field">
+            Footer description
+            <textarea name="footer_description">{{ content.site.footer.description }}</textarea>
+          </label>
         </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>
-              Set new admin password
-              <input type="password" name="admin_password" placeholder="Enter new password" autocomplete="new-password" />
-              <span class="field-help">Leave blank to keep the existing password. Launch with <code>--clear-admin-password</code> to reset to the default.</span>
-            </label>
-          </div>
+        <div class="form-row two-column">
+          <label class="form-field">
+            Footer visit lines (one per row)
+            <textarea name="footer_visit_lines">{{ content.site.footer.visit.lines | join('\n') }}</textarea>
+          </label>
+          <label class="form-field">
+            Footer contact lines (Label|URL — leave URL empty for plain text)
+            <textarea name="footer_contact_lines">{% for line in content.site.footer.contact.lines %}{{ line.label }}{% if line.url %}|{{ line.url }}{% endif %}{% if not loop.last %}\n{% endif %}{% endfor %}</textarea>
+          </label>
         </div>
-      </article>
-
-      <article class="section-card is-editing" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Site identity &amp; theme</h2>
-            <p>Brand, navigation, and global colors</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="true">Done</button>
-        </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Business name</dt>
-              <dd>{{ content.site.name }}</dd>
-            </dl>
-            <dl>
-              <dt>Tagline</dt>
-              <dd>{{ content.site.tagline or '–' }}</dd>
-            </dl>
-            <div class="color-swatches">
-              <div class="color-swatch">
-                <span class="swatch-label">Primary</span>
-                <span class="swatch-color" style="background: {{ content.site.colors.primary }}"></span>
-                <span class="swatch-value">{{ content.site.colors.primary }}</span>
-              </div>
-              <div class="color-swatch">
-                <span class="swatch-label">Accent</span>
-                <span class="swatch-color" style="background: {{ content.site.colors.accent }}"></span>
-                <span class="swatch-value">{{ content.site.colors.accent }}</span>
-              </div>
-              <div class="color-swatch">
-                <span class="swatch-label">Background</span>
-                <span class="swatch-color" style="background: {{ content.site.colors.background }}"></span>
-                <span class="swatch-value">{{ content.site.colors.background }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
+        <div class="form-row">
+          <div class="color-grid">
             <label>
-              Business name
-              <input type="text" name="site_name" value="{{ content.site.name }}" required />
-            </label>
-            <label>
-              Tagline
-              <input type="text" name="site_tagline" value="{{ content.site.tagline }}" />
-            </label>
-          </div>
-          <div class="form-fields">
-            <label>
-              Footer description
-              <textarea name="footer_description">{{ content.site.footer.description }}</textarea>
-            </label>
-          </div>
-          <div class="color-inputs">
-            <label>
-              Primary
+              Primary color
               <input type="color" name="color_primary" value="{{ content.site.colors.primary }}" />
             </label>
             <label>
@@ -491,7 +258,7 @@
               <input type="color" name="color_background" value="{{ content.site.colors.background }}" />
             </label>
             <label>
-              Text
+              Body text
               <input type="color" name="color_text" value="{{ content.site.colors.text }}" />
             </label>
             <label>
@@ -499,553 +266,43 @@
               <input type="color" name="color_muted" value="{{ content.site.colors.muted }}" />
             </label>
           </div>
-          <div class="form-fields">
-            <label>
-              Footer visit lines (one per row)
-              <textarea name="footer_visit_lines">{{ content.site.footer.visit.lines | join('\n') }}</textarea>
-            </label>
-            <label>
-              Footer contact lines (Label|URL — leave URL empty for plain text)
-              <textarea name="footer_contact_lines">{% for line in content.site.footer.contact.lines %}{{ line.label }}{% if line.url %}|{{ line.url }}{% endif %}{% if not loop.last %}\n{% endif %}{% endfor %}</textarea>
-            </label>
-          </div>
         </div>
-      </article>
-
-      <article class="section-card" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Home page</h2>
-            <p>Hero, services overview, trust builders</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="false">Edit section</button>
+        <div class="form-row">
+          <label class="form-field">
+            Set new admin password
+            <input type="password" name="admin_password" placeholder="Enter new password" autocomplete="new-password" />
+            <span class="field-help">
+              {% if admin_password_state == 'custom' %}
+                Using a custom password.
+              {% elif admin_password_state == 'empty' %}
+                No password is currently required.
+              {% else %}
+                The default password is active.
+              {% endif %}
+            </span>
+          </label>
         </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Hero title</dt>
-              <dd>{{ home.hero.title }}</dd>
-            </dl>
-            <dl>
-              <dt>Hero call-to-action</dt>
-              <dd>{{ home.hero.cta_text or '–' }}</dd>
-            </dl>
-            <ul class="preview-list">
-              <li>{{ home['what_we_print'].title }} ({{ home['what_we_print']['items'] | length }} cards)</li>
-              <li>{{ home['why_choose'].title }} ({{ home['why_choose']['items'] | length }} highlights)</li>
-              <li>{{ home['testimonials'].title }} ({{ home['testimonials']['items'] | length }} quotes)</li>
-            </ul>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>Hero badge <input type="text" name="home_hero_badge" value="{{ home.hero.badge }}" /></label>
-            <label>Hero title <input type="text" name="home_hero_title" value="{{ home.hero.title }}" /></label>
-            <label>
-              Hero description
-              <textarea name="home_hero_description">{{ home.hero.description }}</textarea>
-            </label>
-            <label>Hero CTA text <input type="text" name="home_hero_cta_text" value="{{ home.hero.cta_text }}" /></label>
-            <label>Hero CTA link <input type="text" name="home_hero_cta_link" value="{{ home.hero.cta_link }}" /></label>
-            <label>Hero image path
-              <input type="text" name="home_hero_image" value="{{ home.hero.image }}" list="media-options" />
-            </label>
-            <label>Hero image alt text <input type="text" name="home_hero_image_alt" value="{{ home.hero.image_alt }}" /></label>
-          </div>
-
-          <h3>{{ home.what_we_print.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="home_what_we_print_heading" value="{{ home.what_we_print.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="home_what_we_print">
-              {% for item in home.what_we_print['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Card {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="home_what_we_print_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="home_what_we_print_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Card image (optional)
-                    <input
-                      type="text"
-                      name="home_what_we_print_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Card image alt text
-                    <input
-                      type="text"
-                      name="home_what_we_print_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                  <label>Bullet list (one per line)
-                    <textarea name="home_what_we_print_bullets">{{ item.bullets | join('\n') }}</textarea>
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="home_what_we_print_template">Add card</button>
-          </div>
-          <template id="home_what_we_print_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New card</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="home_what_we_print_title" /></label>
-              <label>Description <textarea name="home_what_we_print_description"></textarea></label>
-              <label>
-                Card image (optional)
-                <input type="text" name="home_what_we_print_image" list="media-options" />
-              </label>
-              <label>
-                Card image alt text
-                <input type="text" name="home_what_we_print_image_alt" />
-              </label>
-              <label>Bullet list (one per line)
-                <textarea name="home_what_we_print_bullets"></textarea>
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ home.why_choose.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="home_why_choose_heading" value="{{ home.why_choose.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="home_why_choose">
-              {% for item in home.why_choose['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Card {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="home_why_choose_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="home_why_choose_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Icon/image (optional)
-                    <input
-                      type="text"
-                      name="home_why_choose_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Image alt text
-                    <input
-                      type="text"
-                      name="home_why_choose_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="home_why_choose_template">Add highlight</button>
-          </div>
-          <template id="home_why_choose_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New highlight</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="home_why_choose_title" /></label>
-              <label>Description <textarea name="home_why_choose_description"></textarea></label>
-              <label>
-                Icon/image (optional)
-                <input type="text" name="home_why_choose_image" list="media-options" />
-              </label>
-              <label>
-                Image alt text
-                <input type="text" name="home_why_choose_image_alt" />
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ home.testimonials.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="home_testimonials_heading" value="{{ home.testimonials.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="home_testimonials">
-              {% for item in home.testimonials['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Testimonial {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Quote <textarea name="home_testimonials_quote">{{ item.quote }}</textarea></label>
-                  <label>Attribution <input type="text" name="home_testimonials_author" value="{{ item.author }}" /></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="home_testimonials_template">Add testimonial</button>
-          </div>
-          <template id="home_testimonials_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New testimonial</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Quote <textarea name="home_testimonials_quote"></textarea></label>
-              <label>Attribution <input type="text" name="home_testimonials_author" /></label>
-            </div>
-          </template>
-        </div>
-      </article>
-
-      <article class="section-card" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Services page</h2>
-            <p>Capabilities, bundles, and process</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="false">Edit section</button>
-        </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Hero title</dt>
-              <dd>{{ services.hero.title }}</dd>
-            </dl>
-            <ul class="preview-list">
-              <li>{{ services['capabilities'].title }} ({{ services['capabilities']['items'] | length }} capabilities)</li>
-              <li>{{ services['bundles'].title }} ({{ services['bundles']['items'] | length }} bundles)</li>
-              <li>{{ services.process.title }} ({{ services.process.steps | length }} steps)</li>
-            </ul>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>Hero badge <input type="text" name="services_hero_badge" value="{{ services.hero.badge }}" /></label>
-            <label>Hero title <input type="text" name="services_hero_title" value="{{ services.hero.title }}" /></label>
-            <label>Hero description <textarea name="services_hero_description">{{ services.hero.description }}</textarea></label>
-          </div>
-
-          <h3>{{ services.capabilities.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="services_capabilities_heading" value="{{ services.capabilities.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="services_capabilities">
-              {% for item in services.capabilities['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Capability {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="services_capabilities_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="services_capabilities_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Feature image (optional)
-                    <input
-                      type="text"
-                      name="services_capabilities_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Image alt text
-                    <input
-                      type="text"
-                      name="services_capabilities_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                  <label>Bullet list (one per line)
-                    <textarea name="services_capabilities_bullets">{{ item.bullets | join('\n') }}</textarea>
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="services_capabilities_template">Add capability</button>
-          </div>
-          <template id="services_capabilities_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New capability</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="services_capabilities_title" /></label>
-              <label>Description <textarea name="services_capabilities_description"></textarea></label>
-              <label>
-                Feature image (optional)
-                <input type="text" name="services_capabilities_image" list="media-options" />
-              </label>
-              <label>
-                Image alt text
-                <input type="text" name="services_capabilities_image_alt" />
-              </label>
-              <label>Bullet list (one per line)
-                <textarea name="services_capabilities_bullets"></textarea>
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ services.bundles.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="services_bundles_heading" value="{{ services.bundles.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="services_bundles">
-              {% for item in services.bundles['items'] %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Bundle {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="services_bundles_title" value="{{ item.title }}" /></label>
-                  <label>Price <input type="text" name="services_bundles_price" value="{{ item.price }}" /></label>
-                  <label>Description <textarea name="services_bundles_description">{{ item.description }}</textarea></label>
-                  <label>
-                    Bundle image (optional)
-                    <input
-                      type="text"
-                      name="services_bundles_image"
-                      value="{{ item.image | default('', true) }}"
-                      list="media-options"
-                    />
-                  </label>
-                  <label>
-                    Image alt text
-                    <input
-                      type="text"
-                      name="services_bundles_image_alt"
-                      value="{{ item.image_alt | default('', true) }}"
-                    />
-                  </label>
-                  <label>Bullet list (one per line)
-                    <textarea name="services_bundles_bullets">{{ item.bullets | join('\n') }}</textarea>
-                  </label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="services_bundles_template">Add bundle</button>
-          </div>
-          <template id="services_bundles_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New bundle</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="services_bundles_title" /></label>
-              <label>Price <input type="text" name="services_bundles_price" /></label>
-              <label>Description <textarea name="services_bundles_description"></textarea></label>
-              <label>
-                Bundle image (optional)
-                <input type="text" name="services_bundles_image" list="media-options" />
-              </label>
-              <label>
-                Image alt text
-                <input type="text" name="services_bundles_image_alt" />
-              </label>
-              <label>Bullet list (one per line)
-                <textarea name="services_bundles_bullets"></textarea>
-              </label>
-            </div>
-          </template>
-
-          <h3>{{ services.process.title }}</h3>
-          <div class="form-fields">
-            <label>Section title
-              <input type="text" name="services_process_heading" value="{{ services.process.title }}" />
-            </label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="services_process">
-              {% for item in services.process.steps %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Step {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="services_process_title" value="{{ item.title }}" /></label>
-                  <label>Description <textarea name="services_process_description">{{ item.description }}</textarea></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="services_process_template">Add step</button>
-          </div>
-          <template id="services_process_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New step</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="services_process_title" /></label>
-              <label>Description <textarea name="services_process_description"></textarea></label>
-            </div>
-          </template>
-          <div class="form-fields">
-            <label>Process CTA title <input type="text" name="services_process_cta_title" value="{{ services.process.cta.title }}" /></label>
-            <label>Process CTA description <textarea name="services_process_cta_description">{{ services.process.cta.description }}</textarea></label>
-            <label>Process CTA button text <input type="text" name="services_process_cta_text" value="{{ services.process.cta.text }}" /></label>
-            <label>Process CTA link <input type="text" name="services_process_cta_link" value="{{ services.process.cta.link }}" /></label>
-          </div>
-        </div>
-      </article>
-
-      <article class="section-card" data-section>
-        <div class="section-toolbar">
-          <div>
-            <h2>Contact page</h2>
-            <p>Location, business hours, and form fields</p>
-          </div>
-          <button type="button" class="edit-toggle" aria-expanded="false">Edit section</button>
-        </div>
-        <div class="section-preview">
-          <div class="preview-grid">
-            <dl>
-              <dt>Hero title</dt>
-              <dd>{{ contact.hero.title }}</dd>
-            </dl>
-            <dl>
-              <dt>Studio phone</dt>
-              <dd>{{ contact.studio.phone or '–' }}</dd>
-            </dl>
-            <ul class="preview-list">
-              <li>{{ contact.form.fields | length }} form fields</li>
-              <li>{{ contact.about.cards | length }} about cards</li>
-            </ul>
-          </div>
-        </div>
-        <div class="section-body">
-          <div class="form-fields">
-            <label>Hero badge <input type="text" name="contact_hero_badge" value="{{ contact.hero.badge }}" /></label>
-            <label>Hero title <input type="text" name="contact_hero_title" value="{{ contact.hero.title }}" /></label>
-            <label>Hero description <textarea name="contact_hero_description">{{ contact.hero.description }}</textarea></label>
-          </div>
-          <div class="form-fields">
-            <label>Visit title <input type="text" name="contact_visit_title" value="{{ contact.studio.visit_title }}" /></label>
-            <label>Address (one per line)
-              <textarea name="contact_address_lines">{{ contact.studio.address | join('\n') }}</textarea>
-            </label>
-            <label>Hours title <input type="text" name="contact_hours_title" value="{{ contact.studio.hours_title }}" /></label>
-            <label>Hours (one per line)
-              <textarea name="contact_hours_lines">{{ contact.studio.hours | join('\n') }}</textarea>
-            </label>
-            <label>Phone label <input type="text" name="contact_phone_title" value="{{ contact.studio.phone_title }}" /></label>
-            <label>Phone number <input type="text" name="contact_phone" value="{{ contact.studio.phone }}" /></label>
-            <label>Phone link <input type="text" name="contact_phone_href" value="{{ contact.studio.phone_href }}" /></label>
-            <label>Email label <input type="text" name="contact_email_title" value="{{ contact.studio.email_title }}" /></label>
-            <label>Email address <input type="email" name="contact_email" value="{{ contact.studio.email }}" /></label>
-          </div>
-          <div class="form-fields">
-            <label>Form title <input type="text" name="contact_form_title" value="{{ contact.form.title }}" /></label>
-            <label>Submit button text <input type="text" name="contact_form_submit" value="{{ contact.form.submit_text }}" /></label>
-          </div>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="contact_form_fields">
-              {% for field in contact.form.fields %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Field {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Label <input type="text" name="contact_form_label" value="{{ field.label }}" /></label>
-                  <label>Name <input type="text" name="contact_form_name" value="{{ field.name }}" /></label>
-                  <label>Type
-                    <select name="contact_form_type">
-                      <option value="text" {% if field.type == 'text' %}selected{% endif %}>Text</option>
-                      <option value="email" {% if field.type == 'email' %}selected{% endif %}>Email</option>
-                      <option value="textarea" {% if field.type == 'textarea' %}selected{% endif %}>Textarea</option>
-                    </select>
-                  </label>
-                  <label>Placeholder <input type="text" name="contact_form_placeholder" value="{{ field.placeholder }}" /></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="contact_form_template">Add form field</button>
-          </div>
-          <template id="contact_form_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New field</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Label <input type="text" name="contact_form_label" /></label>
-              <label>Name <input type="text" name="contact_form_name" /></label>
-              <label>Type
-                <select name="contact_form_type">
-                  <option value="text">Text</option>
-                  <option value="email">Email</option>
-                  <option value="textarea">Textarea</option>
-                </select>
-              </label>
-              <label>Placeholder <input type="text" name="contact_form_placeholder" /></label>
-            </div>
-          </template>
-
-          <h3>{{ contact.about.title }}</h3>
-          <label>About title <input type="text" name="contact_about_title" value="{{ contact.about.title }}" /></label>
-          <label>About description <textarea name="contact_about_description">{{ contact.about.description }}</textarea></label>
-          <div class="collection-wrapper">
-            <div class="collection" data-collection="contact_about_cards">
-              {% for card in contact.about.cards %}
-                <div class="collection-item">
-                  <div class="collection-item-header">
-                    <strong>Card {{ loop.index }}</strong>
-                    <button type="button" class="remove-item">Remove</button>
-                  </div>
-                  <label>Title <input type="text" name="contact_about_title_item" value="{{ card.title }}" /></label>
-                  <label>Description <textarea name="contact_about_description_item">{{ card.description }}</textarea></label>
-                </div>
-              {% endfor %}
-            </div>
-            <button type="button" class="add-item" data-template="contact_about_template">Add card</button>
-          </div>
-          <template id="contact_about_template">
-            <div class="collection-item">
-              <div class="collection-item-header">
-                <strong>New card</strong>
-                <button type="button" class="remove-item">Remove</button>
-              </div>
-              <label>Title <input type="text" name="contact_about_title_item" /></label>
-              <label>Description <textarea name="contact_about_description_item"></textarea></label>
-            </div>
-          </template>
-        </div>
-      </article>
-
-      <div class="admin-actions">
-        <button class="primary-button" type="submit">Save changes</button>
       </div>
+      <button class="primary-button" type="submit">Save settings</button>
     </form>
 
     <article class="section-card">
-      <div class="section-toolbar">
-        <div>
-          <h2>Media library</h2>
-          <p>Upload hero images or gallery assets</p>
-        </div>
-      </div>
+      <header>
+        <h2>Media library</h2>
+      </header>
       <form method="post" enctype="multipart/form-data">
         <input type="hidden" name="action" value="upload_media" />
-        <div class="form-fields">
-          <label>Upload image
+        <div class="form-row two-column">
+          <label class="form-field">
+            Upload image
             <input type="file" name="media" accept="image/*" />
           </label>
-          <div class="file-note">Files are stored in <code>{{ webroot_path }}/uploads</code> and can be referenced by using <code>/uploads/&lt;filename&gt;</code> in image fields.</div>
-          <button class="primary-button" type="submit">Upload file</button>
+          <div class="file-note">
+            Files are saved to <code>{{ webroot_path }}/uploads</code>. Reference them with
+            <code>/uploads/&lt;filename&gt;</code> when editing page content.
+          </div>
         </div>
+        <button class="primary-button" type="submit">Upload file</button>
       </form>
       {% if uploads %}
         <div class="image-grid">
@@ -1062,44 +319,4 @@
     </article>
   </section>
 {% endblock %}
-{% block extra_scripts %}
-  <script>
-    const sections = document.querySelectorAll('[data-section]');
-    sections.forEach((section, index) => {
-      const toggle = section.querySelector('.edit-toggle');
-      if (!toggle) return;
-      if (index !== 0) {
-        toggle.textContent = 'Edit section';
-        toggle.setAttribute('aria-expanded', 'false');
-      }
-      toggle.addEventListener('click', () => {
-        const isEditing = section.classList.toggle('is-editing');
-        toggle.textContent = isEditing ? 'Done' : 'Edit section';
-        toggle.setAttribute('aria-expanded', String(isEditing));
-      });
-    });
-
-    document.querySelectorAll('.add-item').forEach((button) => {
-      button.addEventListener('click', () => {
-        const template = document.getElementById(button.dataset.template);
-        if (!template) return;
-        const clone = template.content.firstElementChild.cloneNode(true);
-        const wrapper = button.closest('.collection-wrapper');
-        const collection = wrapper?.querySelector('.collection');
-        collection?.appendChild(clone);
-        attachRemoveHandlers(clone);
-      });
-    });
-
-    function attachRemoveHandlers(scope = document) {
-      scope.querySelectorAll('.remove-item').forEach((button) => {
-        button.addEventListener('click', () => {
-          const item = button.closest('.collection-item');
-          item?.remove();
-        });
-      });
-    }
-
-    attachRemoveHandlers();
-  </script>
-{% endblock %}
+{% block extra_scripts %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,31 @@
     </style>
     {% block extra_head %}{% endblock %}
   </head>
-  <body class="{{ body_class|default('', true) }}">
+  <body
+    class="{{ body_class|default('', true) }}"
+    data-page-key="{{ page_key|default('', true) }}"
+    data-admin-mode="{{ 1 if admin_mode|default(false) else 0 }}"
+  >
+    {% if admin_mode|default(false) %}
+      <div class="admin-toolbar" role="status">
+        <span class="admin-toolbar__label">Admin mode is active</span>
+        <a class="admin-toolbar__link" href="{{ url_for('admin_dashboard') }}">Site settings</a>
+        <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+          <input type="hidden" name="action" value="save_exit" />
+          <input type="hidden" name="next" value="{{ request.path }}" />
+          <button type="submit" class="admin-toolbar__button admin-toolbar__button--primary">
+            Save &amp; exit
+          </button>
+        </form>
+        <form method="post" action="{{ url_for('admin_mode_toggle') }}">
+          <input type="hidden" name="action" value="discard_exit" />
+          <input type="hidden" name="next" value="{{ request.path }}" />
+          <button type="submit" class="admin-toolbar__button admin-toolbar__button--ghost">
+            Discard draft
+          </button>
+        </form>
+      </div>
+    {% endif %}
     <header>
       <div class="navbar">
         <a class="logo" href="{{ url_for('home') }}">{{ content.site.name }}</a>
@@ -42,7 +66,7 @@
             {% endfor %}
             <li>
               <a
-                href="{{ url_for('admin_dashboard') }}"
+                href="{{ url_for('admin_login') }}"
                 class="admin-link {% if request.path.startswith('/admin') %}active{% endif %}"
                 >Admin</a
               >
@@ -92,6 +116,9 @@
     <script>
       document.getElementById('year').textContent = new Date().getFullYear();
     </script>
+    {% if admin_mode|default(false) %}
+      <script src="{{ url_for('static', filename='js/admin-mode.js') }}" defer></script>
+    {% endif %}
     {% block extra_scripts %}{% endblock %}
   </body>
 </html>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,64 +1,177 @@
 {% extends 'base.html' %}
 {% block content %}
-  <section class="hero">
+  {% if admin_mode %}
+    <div class="page-editor is-open" data-page-editor="contact">
+      <div class="page-editor__header">
+        <h2 class="page-editor__title">Contact page editor</h2>
+        <button type="button" class="page-editor__toggle" data-editor-toggle>Hide editor</button>
+      </div>
+      <form class="page-editor__body" data-editor-form>
+        <input type="hidden" name="page" value="contact" />
+        <p class="editor-hint">Keep location, form fields, and about text up to date from here.</p>
+        <div class="form-fields">
+          <label>Hero badge <input type="text" name="contact_hero_badge" value="{{ contact.hero.badge }}" /></label>
+          <label>Hero title <input type="text" name="contact_hero_title" value="{{ contact.hero.title }}" /></label>
+          <label>Hero description <textarea name="contact_hero_description">{{ contact.hero.description }}</textarea></label>
+        </div>
+
+        <h3>Studio information</h3>
+        <div class="form-fields">
+          <label>Visit title <input type="text" name="contact_visit_title" value="{{ contact.studio.visit_title }}" /></label>
+          <label>Address lines <textarea name="contact_address_lines">{{ contact.studio.address | join('\n') }}</textarea></label>
+          <label>Hours title <input type="text" name="contact_hours_title" value="{{ contact.studio.hours_title }}" /></label>
+          <label>Hours lines <textarea name="contact_hours_lines">{{ contact.studio.hours | join('\n') }}</textarea></label>
+          <label>Phone title <input type="text" name="contact_phone_title" value="{{ contact.studio.phone_title }}" /></label>
+          <label>Phone number <input type="text" name="contact_phone" value="{{ contact.studio.phone }}" /></label>
+          <label>Phone link (tel:) <input type="text" name="contact_phone_href" value="{{ contact.studio.phone_href }}" /></label>
+          <label>Email title <input type="text" name="contact_email_title" value="{{ contact.studio.email_title }}" /></label>
+          <label>Email address <input type="email" name="contact_email" value="{{ contact.studio.email }}" /></label>
+        </div>
+
+        <h3>Contact form</h3>
+        <div class="form-fields">
+          <label>Form title <input type="text" name="contact_form_title" value="{{ contact.form.title }}" /></label>
+          <label>Submit button <input type="text" name="contact_form_submit" value="{{ contact.form.submit_text }}" /></label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="contact_form">
+            {% for field in contact.form.fields %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Field {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Label <input type="text" name="contact_form_label" value="{{ field.label }}" /></label>
+                <label>Name <input type="text" name="contact_form_name" value="{{ field.name }}" /></label>
+                <label>Type
+                  <select name="contact_form_type">
+                    <option value="text" {% if field.type == 'text' %}selected{% endif %}>Text</option>
+                    <option value="email" {% if field.type == 'email' %}selected{% endif %}>Email</option>
+                    <option value="textarea" {% if field.type == 'textarea' %}selected{% endif %}>Textarea</option>
+                  </select>
+                </label>
+                <label>Placeholder <input type="text" name="contact_form_placeholder" value="{{ field.placeholder }}" /></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="contact_form_template">Add field</button>
+        </div>
+        <template id="contact_form_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New field</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Label <input type="text" name="contact_form_label" /></label>
+            <label>Name <input type="text" name="contact_form_name" /></label>
+            <label>Type
+              <select name="contact_form_type">
+                <option value="text">Text</option>
+                <option value="email">Email</option>
+                <option value="textarea">Textarea</option>
+              </select>
+            </label>
+            <label>Placeholder <input type="text" name="contact_form_placeholder" /></label>
+          </div>
+        </template>
+
+        <h3>About section</h3>
+        <div class="form-fields">
+          <label>About title <input type="text" name="contact_about_title" value="{{ contact.about.title }}" /></label>
+          <label>About description <textarea name="contact_about_description">{{ contact.about.description }}</textarea></label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="contact_about">
+            {% for card in contact.about.cards %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Card {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="contact_about_title_item" value="{{ card.title }}" /></label>
+                <label>Description <textarea name="contact_about_description_item">{{ card.description }}</textarea></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="contact_about_template">Add card</button>
+        </div>
+        <template id="contact_about_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New card</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="contact_about_title_item" /></label>
+            <label>Description <textarea name="contact_about_description_item"></textarea></label>
+          </div>
+        </template>
+      </form>
+    </div>
+  {% endif %}
+
+  <section class="hero" data-preview-section="contact-hero">
     <div class="hero-content">
       <div>
-        <span class="badge">{{ contact.hero.badge }}</span>
-        <h1>{{ contact.hero.title }}</h1>
-        <p>{{ contact.hero.description }}</p>
+        <span class="badge" data-slot="contact.hero.badge">{{ contact.hero.badge }}</span>
+        <h1 data-slot="contact.hero.title">{{ contact.hero.title }}</h1>
+        <p data-slot="contact.hero.description">{{ contact.hero.description }}</p>
       </div>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-preview-section="contact-details">
     <div class="grid" style="max-width: 960px">
-      <div class="contact-card">
-        <strong>{{ contact.studio.visit_title }}</strong>
-        <div>
+      <div class="contact-card" data-preview-studio>
+        <strong data-slot="contact.studio.visit_title">{{ contact.studio.visit_title }}</strong>
+        <div data-list="contact.studio.address">
           {% for line in contact.studio.address %}
-            {{ line }}<br />
-          {% endfor %}
-        </div>
-        <div>
-          <strong>{{ contact.studio.hours_title }}</strong>
-          {% for line in contact.studio.hours %}
             <div>{{ line }}</div>
           {% endfor %}
         </div>
         <div>
-          <strong>{{ contact.studio.phone_title }}</strong>
-          <a href="tel:{{ contact.studio.phone_href }}">{{ contact.studio.phone }}</a>
+          <strong data-slot="contact.studio.hours_title">{{ contact.studio.hours_title }}</strong>
+          <div data-list="contact.studio.hours">
+            {% for line in contact.studio.hours %}
+              <div>{{ line }}</div>
+            {% endfor %}
+          </div>
         </div>
         <div>
-          <strong>{{ contact.studio.email_title }}</strong>
-          <a href="mailto:{{ contact.studio.email }}">{{ contact.studio.email }}</a>
+          <strong data-slot="contact.studio.phone_title">{{ contact.studio.phone_title }}</strong>
+          <a href="tel:{{ contact.studio.phone_href }}" data-slot-link="contact.studio.phone">{{ contact.studio.phone }}</a>
+        </div>
+        <div>
+          <strong data-slot="contact.studio.email_title">{{ contact.studio.email_title }}</strong>
+          <a href="mailto:{{ contact.studio.email }}" data-slot-link="contact.studio.email">{{ contact.studio.email }}</a>
         </div>
       </div>
 
-      <div class="contact-card">
-        <strong>{{ contact.form.title }}</strong>
+      <div class="contact-card" data-preview-form>
+        <strong data-slot="contact.form.title">{{ contact.form.title }}</strong>
         <form class="contact-form">
-          {% for field in contact.form.fields %}
-            <label>
-              {{ field.label }}
-              {% if field.type == 'textarea' %}
-                <textarea name="{{ field.name }}" placeholder="{{ field.placeholder }}"></textarea>
-              {% else %}
-                <input type="{{ field.type }}" name="{{ field.name }}" placeholder="{{ field.placeholder }}" />
-              {% endif %}
-            </label>
-          {% endfor %}
-          <button class="primary-button" type="submit">{{ contact.form.submit_text }}</button>
+          <div data-repeat="contact.form.fields">
+            {% for field in contact.form.fields %}
+              <label data-field>
+                <span class="field-label">{{ field.label }}</span>
+                {% if field.type == 'textarea' %}
+                  <textarea name="{{ field.name }}" placeholder="{{ field.placeholder }}"></textarea>
+                {% else %}
+                  <input type="{{ field.type }}" name="{{ field.name }}" placeholder="{{ field.placeholder }}" />
+                {% endif %}
+              </label>
+            {% endfor %}
+          </div>
+          <button class="primary-button" type="submit" data-slot="contact.form.submit_text">{{ contact.form.submit_text }}</button>
         </form>
       </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="contact-about">
     <div class="grid" style="max-width: 900px">
-      <h2>{{ contact.about.title }}</h2>
-      <p>{{ contact.about.description }}</p>
-      <div class="grid grid-3">
+      <h2 data-slot="contact.about.title">{{ contact.about.title }}</h2>
+      <p data-slot="contact.about.description">{{ contact.about.description }}</p>
+      <div class="grid grid-3" data-repeat="contact.about.cards">
         {% for card in contact.about.cards %}
           <article class="card">
             <h3>{{ card.title }}</h3>
@@ -68,4 +181,19 @@
       </div>
     </div>
   </section>
+
+  {% if admin_mode %}
+    <template id="tpl-contact-form-field">
+      <label data-field>
+        <span class="field-label"></span>
+        <input type="text" />
+      </label>
+    </template>
+    <template id="tpl-contact-about-card">
+      <article class="card">
+        <h3></h3>
+        <p></p>
+      </article>
+    </template>
+  {% endif %}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,58 +1,227 @@
 {% extends 'base.html' %}
 {% block content %}
-  <section class="hero">
+  {% if admin_mode %}
+    <div class="page-editor is-open" data-page-editor="home">
+      <div class="page-editor__header">
+        <h2 class="page-editor__title">Home page editor</h2>
+        <button type="button" class="page-editor__toggle" data-editor-toggle>Hide editor</button>
+      </div>
+      <form class="page-editor__body" data-editor-form>
+        <input type="hidden" name="page" value="home" />
+        <p class="editor-hint">Updates apply to the live page preview only while admin mode is active.</p>
+        <div class="form-fields">
+          <label>Hero badge <input type="text" name="home_hero_badge" value="{{ home.hero.badge }}" /></label>
+          <label>Hero title <input type="text" name="home_hero_title" value="{{ home.hero.title }}" /></label>
+          <label>
+            Hero description
+            <textarea name="home_hero_description">{{ home.hero.description }}</textarea>
+          </label>
+          <label>Hero CTA text <input type="text" name="home_hero_cta_text" value="{{ home.hero.cta_text }}" /></label>
+          <label>Hero CTA link <input type="text" name="home_hero_cta_link" value="{{ home.hero.cta_link }}" /></label>
+          <label>
+            Hero image path
+            <input type="text" name="home_hero_image" value="{{ home.hero.image }}" list="media-options" />
+          </label>
+          <label>Hero image alt text <input type="text" name="home_hero_image_alt" value="{{ home.hero.image_alt }}" /></label>
+        </div>
+
+        <h3>{{ home.what_we_print.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="home_what_we_print_heading" value="{{ home.what_we_print.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="home_what_we_print">
+            {% for item in home.what_we_print['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Card {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="home_what_we_print_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="home_what_we_print_description">{{ item.description }}</textarea></label>
+                <label>
+                  Card image
+                  <input type="text" name="home_what_we_print_image" value="{{ item.image }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="home_what_we_print_image_alt" value="{{ item.image_alt }}" />
+                </label>
+                <label>Bullet list (one per line)
+                  <textarea name="home_what_we_print_bullets">{{ item.bullets | join('\n') }}</textarea>
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="home_what_we_print_template">Add card</button>
+        </div>
+        <template id="home_what_we_print_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New card</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="home_what_we_print_title" /></label>
+            <label>Description <textarea name="home_what_we_print_description"></textarea></label>
+            <label>
+              Card image
+              <input type="text" name="home_what_we_print_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="home_what_we_print_image_alt" />
+            </label>
+            <label>Bullet list (one per line)
+              <textarea name="home_what_we_print_bullets"></textarea>
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ home.why_choose.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="home_why_choose_heading" value="{{ home.why_choose.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="home_why_choose">
+            {% for item in home.why_choose['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Highlight {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="home_why_choose_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="home_why_choose_description">{{ item.description }}</textarea></label>
+                <label>
+                  Icon/image
+                  <input type="text" name="home_why_choose_image" value="{{ item.image | default('', true) }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="home_why_choose_image_alt" value="{{ item.image_alt | default('', true) }}" />
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="home_why_choose_template">Add highlight</button>
+        </div>
+        <template id="home_why_choose_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New highlight</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="home_why_choose_title" /></label>
+            <label>Description <textarea name="home_why_choose_description"></textarea></label>
+            <label>
+              Icon/image
+              <input type="text" name="home_why_choose_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="home_why_choose_image_alt" />
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ home.testimonials.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="home_testimonials_heading" value="{{ home.testimonials.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="home_testimonials">
+            {% for item in home.testimonials['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Testimonial {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Quote <textarea name="home_testimonials_quote">{{ item.quote }}</textarea></label>
+                <label>Attribution <input type="text" name="home_testimonials_author" value="{{ item.author }}" /></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="home_testimonials_template">Add testimonial</button>
+        </div>
+        <template id="home_testimonials_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New testimonial</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Quote <textarea name="home_testimonials_quote"></textarea></label>
+            <label>Attribution <input type="text" name="home_testimonials_author" /></label>
+          </div>
+        </template>
+
+        <datalist id="media-options">
+          <option value=""></option>
+          {% for upload in editor_uploads %}
+            <option value="/uploads/{{ upload }}">/uploads/{{ upload }}</option>
+          {% endfor %}
+        </datalist>
+      </form>
+    </div>
+  {% endif %}
+
+  <section class="hero" data-preview-section="home-hero">
     <div class="hero-content">
       <div>
-        <span class="badge">{{ home.hero.badge }}</span>
-        <h1>{{ home.hero.title }}</h1>
-        <p>{{ home.hero.description }}</p>
-        <a class="primary-button" href="{{ home.hero.cta_link }}">{{ home.hero.cta_text }}</a>
+        <span class="badge" data-slot="home.hero.badge">{{ home.hero.badge }}</span>
+        <h1 data-slot="home.hero.title">{{ home.hero.title }}</h1>
+        <p data-slot="home.hero.description">{{ home.hero.description }}</p>
+        <a class="primary-button" href="{{ home.hero.cta_link }}" data-slot-link="home.hero.cta">
+          {{ home.hero.cta_text }}
+        </a>
       </div>
-      {% if home.hero.image %}
-        <div class="hero-image">
+      <div class="hero-image" data-slot-container="home.hero.image" {% if not home.hero.image %}hidden{% endif %}>
+        {% if home.hero.image %}
           <img src="{{ home.hero.image }}" alt="{{ home.hero.image_alt }}" />
-        </div>
-      {% endif %}
+        {% endif %}
+      </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="home-what-we-print">
     <div class="grid">
-      <h2>{{ home.what_we_print.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="home.what_we_print.title">{{ home.what_we_print.title }}</h2>
+      <div class="grid grid-3" data-repeat="home.what_we_print.items">
         {% for item in home.what_we_print["items"] %}
           <article class="card">
-            {% if item.image %}
-              <div class="card-media">
+            <div class="card-media" data-image-container {% if not item.image %}hidden{% endif %}>
+              {% if item.image %}
                 <img src="{{ item.image }}" alt="{{ item.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ item.title }}</h3>
             <p>{{ item.description }}</p>
-            {% if item.bullets %}
-              <ul class="checklist">
-                {% for bullet in item.bullets %}
-                  <li>{{ bullet }}</li>
-                {% endfor %}
-              </ul>
-            {% endif %}
+            <ul class="checklist" data-list {% if not item.bullets %}hidden{% endif %}>
+              {% for bullet in item.bullets %}
+                <li>{{ bullet }}</li>
+              {% endfor %}
+            </ul>
           </article>
         {% endfor %}
       </div>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-preview-section="home-why-choose">
     <div class="grid">
-      <h2>{{ home.why_choose.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="home.why_choose.title">{{ home.why_choose.title }}</h2>
+      <div class="grid grid-3" data-repeat="home.why_choose.items">
         {% for item in home.why_choose["items"] %}
           <article class="card">
-            {% if item.image %}
-              <div class="card-media compact">
+            <div class="card-media compact" data-image-container {% if not item.image %}hidden{% endif %}>
+              {% if item.image %}
                 <img src="{{ item.image }}" alt="{{ item.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ item.title }}</h3>
             <p>{{ item.description }}</p>
           </article>
@@ -61,10 +230,10 @@
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="home-testimonials">
     <div class="grid">
-      <h2>{{ home.testimonials.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="home.testimonials.title">{{ home.testimonials.title }}</h2>
+      <div class="grid grid-3" data-repeat="home.testimonials.items">
         {% for testimonial in home.testimonials["items"] %}
           <article class="card testimonial">
             <p>{{ testimonial.quote }}</p>
@@ -74,4 +243,28 @@
       </div>
     </div>
   </section>
+
+  {% if admin_mode %}
+    <template id="tpl-home-what-we-print">
+      <article class="card">
+        <div class="card-media" data-image-container hidden></div>
+        <h3></h3>
+        <p></p>
+        <ul class="checklist" data-list hidden></ul>
+      </article>
+    </template>
+    <template id="tpl-home-why-choose">
+      <article class="card">
+        <div class="card-media compact" data-image-container hidden></div>
+        <h3></h3>
+        <p></p>
+      </article>
+    </template>
+    <template id="tpl-home-testimonial">
+      <article class="card testimonial">
+        <p></p>
+        <cite></cite>
+      </article>
+    </template>
+  {% endif %}
 {% endblock %}

--- a/templates/services.html
+++ b/templates/services.html
@@ -1,74 +1,245 @@
 {% extends 'base.html' %}
 {% block content %}
-  <section class="hero">
+  {% if admin_mode %}
+    <div class="page-editor is-open" data-page-editor="services">
+      <div class="page-editor__header">
+        <h2 class="page-editor__title">Services page editor</h2>
+        <button type="button" class="page-editor__toggle" data-editor-toggle>Hide editor</button>
+      </div>
+      <form class="page-editor__body" data-editor-form>
+        <input type="hidden" name="page" value="services" />
+        <p class="editor-hint">Adjust copy, pricing, and workflow steps directly from this panel.</p>
+        <div class="form-fields">
+          <label>Hero badge <input type="text" name="services_hero_badge" value="{{ services.hero.badge }}" /></label>
+          <label>Hero title <input type="text" name="services_hero_title" value="{{ services.hero.title }}" /></label>
+          <label>Hero description <textarea name="services_hero_description">{{ services.hero.description }}</textarea></label>
+        </div>
+
+        <h3>{{ services.capabilities.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="services_capabilities_heading" value="{{ services.capabilities.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="services_capabilities">
+            {% for item in services.capabilities['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Capability {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="services_capabilities_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="services_capabilities_description">{{ item.description }}</textarea></label>
+                <label>
+                  Feature image
+                  <input type="text" name="services_capabilities_image" value="{{ item.image | default('', true) }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="services_capabilities_image_alt" value="{{ item.image_alt | default('', true) }}" />
+                </label>
+                <label>Bullet list (one per line)
+                  <textarea name="services_capabilities_bullets">{{ item.bullets | join('\n') }}</textarea>
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="services_capabilities_template">Add capability</button>
+        </div>
+        <template id="services_capabilities_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New capability</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="services_capabilities_title" /></label>
+            <label>Description <textarea name="services_capabilities_description"></textarea></label>
+            <label>
+              Feature image
+              <input type="text" name="services_capabilities_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="services_capabilities_image_alt" />
+            </label>
+            <label>Bullet list (one per line)
+              <textarea name="services_capabilities_bullets"></textarea>
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ services.bundles.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="services_bundles_heading" value="{{ services.bundles.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="services_bundles">
+            {% for item in services.bundles['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Bundle {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="services_bundles_title" value="{{ item.title }}" /></label>
+                <label>Price <input type="text" name="services_bundles_price" value="{{ item.price }}" /></label>
+                <label>Description <textarea name="services_bundles_description">{{ item.description }}</textarea></label>
+                <label>
+                  Bundle image
+                  <input type="text" name="services_bundles_image" value="{{ item.image | default('', true) }}" list="media-options" />
+                </label>
+                <label>
+                  Image alt text
+                  <input type="text" name="services_bundles_image_alt" value="{{ item.image_alt | default('', true) }}" />
+                </label>
+                <label>Bullet list (one per line)
+                  <textarea name="services_bundles_bullets">{{ item.bullets | join('\n') }}</textarea>
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="services_bundles_template">Add bundle</button>
+        </div>
+        <template id="services_bundles_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New bundle</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="services_bundles_title" /></label>
+            <label>Price <input type="text" name="services_bundles_price" /></label>
+            <label>Description <textarea name="services_bundles_description"></textarea></label>
+            <label>
+              Bundle image
+              <input type="text" name="services_bundles_image" list="media-options" />
+            </label>
+            <label>
+              Image alt text
+              <input type="text" name="services_bundles_image_alt" />
+            </label>
+            <label>Bullet list (one per line)
+              <textarea name="services_bundles_bullets"></textarea>
+            </label>
+          </div>
+        </template>
+
+        <h3>{{ services.process.title }}</h3>
+        <div class="form-fields">
+          <label>Section title
+            <input type="text" name="services_process_heading" value="{{ services.process.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="services_process">
+            {% for item in services.process.steps %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Step {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="services_process_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="services_process_description">{{ item.description }}</textarea></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="services_process_template">Add step</button>
+        </div>
+        <template id="services_process_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New step</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="services_process_title" /></label>
+            <label>Description <textarea name="services_process_description"></textarea></label>
+          </div>
+        </template>
+
+        <div class="form-fields">
+          <label>Call-to-action title <input type="text" name="services_process_cta_title" value="{{ services.process.cta.title }}" /></label>
+          <label>
+            Call-to-action description
+            <textarea name="services_process_cta_description">{{ services.process.cta.description }}</textarea>
+          </label>
+          <label>Button text <input type="text" name="services_process_cta_text" value="{{ services.process.cta.text }}" /></label>
+          <label>Button link <input type="text" name="services_process_cta_link" value="{{ services.process.cta.link }}" /></label>
+        </div>
+
+        <datalist id="media-options">
+          <option value=""></option>
+          {% for upload in editor_uploads %}
+            <option value="/uploads/{{ upload }}">/uploads/{{ upload }}</option>
+          {% endfor %}
+        </datalist>
+      </form>
+    </div>
+  {% endif %}
+
+  <section class="hero" data-preview-section="services-hero">
     <div class="hero-content">
       <div class="service-hero">
-        <span class="badge">{{ services.hero.badge }}</span>
-        <h1>{{ services.hero.title }}</h1>
-        <p>{{ services.hero.description }}</p>
+        <span class="badge" data-slot="services.hero.badge">{{ services.hero.badge }}</span>
+        <h1 data-slot="services.hero.title">{{ services.hero.title }}</h1>
+        <p data-slot="services.hero.description">{{ services.hero.description }}</p>
       </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="services-capabilities">
     <div class="grid">
-      <h2>{{ services.capabilities.title }}</h2>
-      <div class="grid grid-3">
-        {% for item in services.capabilities["items"] %}
+      <h2 data-slot="services.capabilities.title">{{ services.capabilities.title }}</h2>
+      <div class="grid grid-3" data-repeat="services.capabilities.items">
+        {% for item in services.capabilities['items'] %}
           <article class="card">
-            {% if item.image %}
-              <div class="card-media">
+            <div class="card-media" data-image-container {% if not item.image %}hidden{% endif %}>
+              {% if item.image %}
                 <img src="{{ item.image }}" alt="{{ item.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ item.title }}</h3>
             <p>{{ item.description }}</p>
-            {% if item.bullets %}
-              <ul class="checklist">
-                {% for bullet in item.bullets %}
-                  <li>{{ bullet }}</li>
-                {% endfor %}
-              </ul>
-            {% endif %}
+            <ul class="checklist" data-list {% if not item.bullets %}hidden{% endif %}>
+              {% for bullet in item.bullets %}
+                <li>{{ bullet }}</li>
+              {% endfor %}
+            </ul>
           </article>
         {% endfor %}
       </div>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-preview-section="services-bundles">
     <div class="grid">
-      <h2>{{ services.bundles.title }}</h2>
-      <div class="grid grid-3">
-        {% for bundle in services.bundles["items"] %}
+      <h2 data-slot="services.bundles.title">{{ services.bundles.title }}</h2>
+      <div class="grid grid-3" data-repeat="services.bundles.items">
+        {% for bundle in services.bundles['items'] %}
           <article class="card">
-            {% if bundle.image %}
-              <div class="card-media">
+            <div class="card-media" data-image-container {% if not bundle.image %}hidden{% endif %}>
+              {% if bundle.image %}
                 <img src="{{ bundle.image }}" alt="{{ bundle.image_alt }}" loading="lazy" />
-              </div>
-            {% endif %}
+              {% endif %}
+            </div>
             <h3>{{ bundle.title }}</h3>
-            {% if bundle.price %}
-              <div class="price">{{ bundle.price }}</div>
-            {% endif %}
+            <div class="price" data-slot="services.bundles.price">{{ bundle.price }}</div>
             <p>{{ bundle.description }}</p>
-            {% if bundle.bullets %}
-              <ul class="checklist">
-                {% for bullet in bundle.bullets %}
-                  <li>{{ bullet }}</li>
-                {% endfor %}
-              </ul>
-            {% endif %}
+            <ul class="checklist" data-list {% if not bundle.bullets %}hidden{% endif %}>
+              {% for bullet in bundle.bullets %}
+                <li>{{ bullet }}</li>
+              {% endfor %}
+            </ul>
           </article>
         {% endfor %}
       </div>
     </div>
   </section>
 
-  <section class="section alt">
+  <section class="section alt" data-preview-section="services-process">
     <div class="grid" style="max-width: 980px">
-      <h2>{{ services.process.title }}</h2>
-      <div class="grid grid-3">
+      <h2 data-slot="services.process.title">{{ services.process.title }}</h2>
+      <div class="grid grid-3" data-repeat="services.process.steps">
         {% for step in services.process.steps %}
           <article class="card">
             <h3>{{ step.title }}</h3>
@@ -76,11 +247,39 @@
           </article>
         {% endfor %}
       </div>
-      <div class="card" style="margin-top: 2rem; text-align: center">
-        <h3>{{ services.process.cta.title }}</h3>
-        <p>{{ services.process.cta.description }}</p>
-        <a class="primary-button" href="{{ services.process.cta.link }}">{{ services.process.cta.text }}</a>
+      <div class="card" style="margin-top: 2rem; text-align: center" data-preview-cta>
+        <h3 data-slot="services.process.cta.title">{{ services.process.cta.title }}</h3>
+        <p data-slot="services.process.cta.description">{{ services.process.cta.description }}</p>
+        <a class="primary-button" href="{{ services.process.cta.link }}" data-slot-link="services.process.cta">
+          {{ services.process.cta.text }}
+        </a>
       </div>
     </div>
   </section>
+
+  {% if admin_mode %}
+    <template id="tpl-services-capability">
+      <article class="card">
+        <div class="card-media" data-image-container hidden></div>
+        <h3></h3>
+        <p></p>
+        <ul class="checklist" data-list hidden></ul>
+      </article>
+    </template>
+    <template id="tpl-services-bundle">
+      <article class="card">
+        <div class="card-media" data-image-container hidden></div>
+        <h3></h3>
+        <div class="price"></div>
+        <p></p>
+        <ul class="checklist" data-list hidden></ul>
+      </article>
+    </template>
+    <template id="tpl-services-step">
+      <article class="card">
+        <h3></h3>
+        <p></p>
+      </article>
+    </template>
+  {% endif %}
 {% endblock %}

--- a/templates/store.html
+++ b/templates/store.html
@@ -1,0 +1,252 @@
+{% extends 'base.html' %}
+{% block content %}
+  {% if admin_mode %}
+    <div class="page-editor is-open" data-page-editor="store">
+      <div class="page-editor__header">
+        <h2 class="page-editor__title">Store page editor</h2>
+        <button type="button" class="page-editor__toggle" data-editor-toggle>Hide editor</button>
+      </div>
+      <form class="page-editor__body" data-editor-form>
+        <input type="hidden" name="page" value="store" />
+        <p class="editor-hint">Updates apply to the preview while admin mode is active. Exit admin mode to publish.</p>
+        <div class="form-fields">
+          <label>Hero badge <input type="text" name="store_hero_badge" value="{{ store.hero.badge }}" /></label>
+          <label>Hero title <input type="text" name="store_hero_title" value="{{ store.hero.title }}" /></label>
+          <label>
+            Hero description
+            <textarea name="store_hero_description">{{ store.hero.description }}</textarea>
+          </label>
+          <label>Hero CTA text <input type="text" name="store_hero_cta_text" value="{{ store.hero.cta_text }}" /></label>
+          <label>Hero CTA link <input type="text" name="store_hero_cta_link" value="{{ store.hero.cta_link }}" /></label>
+        </div>
+
+        <h3>{{ store.promises.title }}</h3>
+        <div class="form-fields">
+          <label>Highlights heading
+            <input type="text" name="store_promises_heading" value="{{ store.promises.title }}" />
+          </label>
+        </div>
+        <div class="collection-wrapper">
+          <div class="collection" data-collection="store_promises">
+            {% for item in store.promises['items'] %}
+              <div class="collection-item">
+                <div class="collection-item-header">
+                  <strong>Highlight {{ loop.index }}</strong>
+                  <button type="button" class="remove-item">Remove</button>
+                </div>
+                <label>Title <input type="text" name="store_promises_title" value="{{ item.title }}" /></label>
+                <label>Description <textarea name="store_promises_description">{{ item.description }}</textarea></label>
+              </div>
+            {% endfor %}
+          </div>
+          <button type="button" class="add-item" data-template="store_promises_template">Add highlight</button>
+        </div>
+        <template id="store_promises_template">
+          <div class="collection-item">
+            <div class="collection-item-header">
+              <strong>New highlight</strong>
+              <button type="button" class="remove-item">Remove</button>
+            </div>
+            <label>Title <input type="text" name="store_promises_title" /></label>
+            <label>Description <textarea name="store_promises_description"></textarea></label>
+          </div>
+        </template>
+
+        <h3>Support block</h3>
+        <div class="form-fields">
+          <label>Title <input type="text" name="store_support_title" value="{{ store.support.title }}" /></label>
+          <label>
+            Description
+            <textarea name="store_support_description">{{ store.support.description }}</textarea>
+          </label>
+          <label>CTA text <input type="text" name="store_support_cta_text" value="{{ store.support.cta_text }}" /></label>
+          <label>CTA link <input type="text" name="store_support_cta_link" value="{{ store.support.cta_link }}" /></label>
+        </div>
+      </form>
+    </div>
+  {% endif %}
+
+  <section class="hero store-hero" data-preview-section="store-hero">
+    <div class="hero-content store-hero__content">
+      <div class="store-hero__copy">
+        <span class="badge" data-slot="store.hero.badge">{{ store.hero.badge }}</span>
+        <h1 data-slot="store.hero.title">{{ store.hero.title }}</h1>
+        <p data-slot="store.hero.description">{{ store.hero.description }}</p>
+        <a class="primary-button" href="{{ store.hero.cta_link }}" data-slot-link="store.hero.cta">
+          {{ store.hero.cta_text }}
+        </a>
+      </div>
+      <div class="store-hero__stats">
+        <div class="store-hero__stat">
+          <strong>{{ inventory_count }}</strong>
+          <span>Printers curated</span>
+        </div>
+        <div class="store-hero__stat">
+          <strong>9</strong>
+          <span>Displayed per page</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section alt store-promises" data-preview-section="store-promises">
+    <div class="grid">
+      <h2 data-slot="store.promises.title">{{ store.promises.title }}</h2>
+      <div class="grid grid-3 store-promises__items" data-repeat="store.promises.items">
+        {% for item in store.promises['items'] %}
+          <article class="card store-promise">
+            <h3>{{ item.title }}</h3>
+            <p>{{ item.description }}</p>
+          </article>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+  <template id="tpl-store-promise">
+    <article class="card store-promise">
+      <h3></h3>
+      <p></p>
+    </article>
+  </template>
+
+  <section class="section store-grid">
+    <div class="grid">
+      <div class="store-grid__intro">
+        <div>
+          <h2>Laser printers &amp; toner bundles</h2>
+          <p>Browse enterprise-ready laser printers from HP, Canon, Kyocera, and Toshiba. Each card pairs the printer with the toner we keep in stock for next-day delivery.</p>
+        </div>
+        <div class="store-grid__meta">
+          <span>Showing {{ printers|length }} of {{ inventory_count }} models</span>
+        </div>
+      </div>
+      <div class="store-grid__items">
+        {% for printer in printers %}
+          <article class="product-card">
+            <div class="product-card__media">
+              <img src="{{ printer.image }}" alt="{{ printer.image_alt }}" loading="lazy" width="640" height="480" />
+            </div>
+            <div class="product-card__body">
+              <span class="product-card__manufacturer">{{ printer.manufacturer }}</span>
+              <h3>{{ printer.model }}</h3>
+              <ul class="product-card__meta">
+                {% if printer.release_year %}
+                  <li><span>Release year</span><strong>{{ printer.release_year }}</strong></li>
+                {% endif %}
+                {% if printer.category %}
+                  <li><span>Category</span><strong>{{ printer.category }}</strong></li>
+                {% endif %}
+                <li><span>Compatible cartridges</span><strong>{{ printer.cartridges|length }}</strong></li>
+              </ul>
+              <div class="product-card__toner">
+                <h4>Compatible toner</h4>
+                <ul>
+                  {% for cartridge in printer.cartridges %}
+                    <li>
+                      <span class="product-card__toner-name">{{ cartridge.name }}</span>
+                      {% if cartridge.part_number %}
+                        <span class="product-card__toner-sku">{{ cartridge.part_number }}</span>
+                      {% endif %}
+                      {% if cartridge.yield_pages %}
+                        <span class="product-card__toner-yield">{{ '{:,}'.format(cartridge.yield_pages) }} pages</span>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+              <div class="product-card__actions">
+                <a
+                  class="primary-button"
+                  href="{{ url_for('contact_page') }}?subject={{ ('Order ' ~ printer.manufacturer ~ ' ' ~ printer.model ~ ' Printer') | urlencode }}"
+                >
+                  Buy printer
+                </a>
+                <a
+                  class="ghost-button"
+                  href="{{ url_for('contact_page') }}?subject={{ ('Order toner for ' ~ printer.manufacturer ~ ' ' ~ printer.model) | urlencode }}"
+                >
+                  Buy toner
+                </a>
+              </div>
+            </div>
+          </article>
+        {% endfor %}
+        {% if printers|length == 0 %}
+          <div class="store-grid__empty">
+            <p>No printers available in this view. Try another page.</p>
+          </div>
+        {% endif %}
+      </div>
+      {% if pagination.total_pages > 1 %}
+        <nav class="store-grid__pagination" aria-label="Printer pagination">
+          <ul>
+            <li>
+              <a
+                class="ghost-button{% if not pagination.has_prev %} disabled{% endif %}"
+                {% if pagination.has_prev %}
+                  href="{{ url_for('store_page', page=pagination.prev_page) }}"
+                {% else %}
+                  aria-disabled="true"
+                {% endif %}
+              >
+                Previous
+              </a>
+            </li>
+            {% for number in pagination.pages %}
+              <li>
+                <a
+                  class="ghost-button{% if number == pagination.page %} active{% endif %}"
+                  {% if number == pagination.page %}
+                    aria-current="page"
+                  {% endif %}
+                  href="{{ url_for('store_page', page=number) }}"
+                >
+                  {{ number }}
+                </a>
+              </li>
+            {% endfor %}
+            <li>
+              <a
+                class="ghost-button{% if not pagination.has_next %} disabled{% endif %}"
+                {% if pagination.has_next %}
+                  href="{{ url_for('store_page', page=pagination.next_page) }}"
+                {% else %}
+                  aria-disabled="true"
+                {% endif %}
+              >
+                Next
+              </a>
+            </li>
+          </ul>
+        </nav>
+      {% endif %}
+    </div>
+  </section>
+
+  <section class="section store-support" data-preview-section="store-support">
+    <div class="grid">
+      <div class="store-support__card">
+        <div>
+          <h2 data-slot="store.support.title">{{ store.support.title }}</h2>
+          <p data-slot="store.support.description">{{ store.support.description }}</p>
+        </div>
+        <a class="primary-button" href="{{ store.support.cta_link }}" data-slot-link="store.support.cta">
+          {{ store.support.cta_text }}
+        </a>
+      </div>
+    </div>
+  </section>
+
+  {% if manufacturer_notes %}
+    <section class="section store-notes">
+      <div class="grid store-notes__grid">
+        {% for note in manufacturer_notes %}
+          <article class="card store-note">
+            <h3>{{ note.manufacturer }}</h3>
+            <p>{{ note.note }}</p>
+          </article>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
+{% endblock %}

--- a/webroot/content.json
+++ b/webroot/content.json
@@ -3,9 +3,22 @@
     "name": "BlueWave Print Studio",
     "tagline": "Local print experts serving the Coastal Bend",
     "navigation": [
-      { "label": "Home", "url": "/" },
-      { "label": "Services", "url": "/services" },
-      { "label": "Contact & About", "url": "/contact" }
+      {
+        "label": "Home",
+        "url": "/"
+      },
+      {
+        "label": "Services",
+        "url": "/services"
+      },
+      {
+        "label": "Store",
+        "url": "/store"
+      },
+      {
+        "label": "Contact & About",
+        "url": "/contact"
+      }
     ],
     "colors": {
       "primary": "#1d4ed8",
@@ -28,9 +41,18 @@
       "contact": {
         "title": "Contact",
         "lines": [
-          { "label": "(361) 555-0198", "url": "tel:13615550198" },
-          { "label": "hello@bluewaveprint.com", "url": "mailto:hello@bluewaveprint.com" },
-          { "label": "Start a project →", "url": "/contact" }
+          {
+            "label": "(361) 555-0198",
+            "url": "tel:13615550198"
+          },
+          {
+            "label": "hello@bluewaveprint.com",
+            "url": "mailto:hello@bluewaveprint.com"
+          },
+          {
+            "label": "Start a project →",
+            "url": "/contact"
+          }
         ]
       },
       "copyright": "All rights reserved."
@@ -38,7 +60,9 @@
   },
   "pages": {
     "home": {
-      "meta": { "title": "Local Print Experts" },
+      "meta": {
+        "title": "Local Print Experts"
+      },
       "hero": {
         "badge": "Locally owned • Est. 1998",
         "title": "Modern printing crafted for businesses that move fast",
@@ -128,7 +152,9 @@
       }
     },
     "services": {
-      "meta": { "title": "Print Services" },
+      "meta": {
+        "title": "Print Services"
+      },
       "hero": {
         "badge": "Fast timelines • Expert finishing",
         "title": "Services engineered to make your brand look its best",
@@ -238,7 +264,9 @@
       }
     },
     "contact": {
-      "meta": { "title": "Contact BlueWave Print Studio" },
+      "meta": {
+        "title": "Contact BlueWave Print Studio"
+      },
       "hero": {
         "badge": "We answer within one business hour",
         "title": "Let’s bring your next print idea to life",
@@ -308,6 +336,41 @@
             "description": "From branding refreshes to multi-location signage rollouts, we serve as a dedicated print partner for 200+ area businesses."
           }
         ]
+      }
+    },
+    "store": {
+      "meta": {
+        "title": "Printer Store"
+      },
+      "hero": {
+        "badge": "Printer Store",
+        "title": "Shop enterprise-ready laser printers",
+        "description": "Explore curated HP, Canon, Kyocera, and Toshiba models with toner pairings we trust for reliable office output.",
+        "cta_text": "Talk with a print specialist",
+        "cta_link": "/contact"
+      },
+      "promises": {
+        "title": "Every order includes",
+        "items": [
+          {
+            "title": "Configured for your workflow",
+            "description": "We stage firmware updates, network settings, and driver bundles so installations are plug-and-play."
+          },
+          {
+            "title": "Guaranteed supply matching",
+            "description": "Each listing includes the toner SKUs we stock, so you never guess about refills."
+          },
+          {
+            "title": "Local service and delivery",
+            "description": "Our technicians can deliver, install, and keep your fleet humming across the Coastal Bend."
+          }
+        ]
+      },
+      "support": {
+        "title": "Need a tailored print plan?",
+        "description": "Bundle printers, managed supplies, and priority service into one agreement built for your team.",
+        "cta_text": "Request a custom quote",
+        "cta_link": "/contact"
       }
     }
   }

--- a/webroot/printer_inventory.json
+++ b/webroot/printer_inventory.json
@@ -1,0 +1,387 @@
+{
+  "generated_at": "2024-05-20",
+  "metadata": {
+    "description": "Laser printer models introduced between 2009 and 2024 with their compatible toner cartridges."
+  },
+  "manufacturers": [
+    {
+      "name": "HP",
+      "models": [
+        {
+          "model": "LaserJet Pro M404n",
+          "category": "Monochrome laser printer",
+          "release_year": 2019,
+          "cartridges": [
+            {
+              "name": "HP 58A Black Original LaserJet Toner Cartridge",
+              "part_number": "CF258A",
+              "yield_pages": 3000
+            },
+            {
+              "name": "HP 58X High Yield Black Original LaserJet Toner Cartridge",
+              "part_number": "CF258X",
+              "yield_pages": 10000
+            }
+          ],
+          "image": "/static/img/printers/hp-laserjet-pro-m404n.svg",
+          "image_alt": "Stylized illustration of the HP LaserJet Pro M404n laser printer"
+        },
+        {
+          "model": "LaserJet Pro M203dw",
+          "category": "Monochrome laser printer",
+          "release_year": 2017,
+          "cartridges": [
+            {
+              "name": "HP 30A Black Original LaserJet Toner Cartridge",
+              "part_number": "CF230A",
+              "yield_pages": 1600
+            },
+            {
+              "name": "HP 30X High Yield Black Original LaserJet Toner Cartridge",
+              "part_number": "CF230X",
+              "yield_pages": 3500
+            }
+          ],
+          "image": "/static/img/printers/hp-laserjet-pro-m203dw.svg",
+          "image_alt": "Stylized illustration of the HP LaserJet Pro M203dw laser printer"
+        },
+        {
+          "model": "LaserJet Enterprise M507dn",
+          "category": "Monochrome laser printer",
+          "release_year": 2019,
+          "cartridges": [
+            {
+              "name": "HP 89A Black Original LaserJet Toner Cartridge",
+              "part_number": "CF289A",
+              "yield_pages": 5000
+            },
+            {
+              "name": "HP 89X High Yield Black Original LaserJet Toner Cartridge",
+              "part_number": "CF289X",
+              "yield_pages": 10000
+            },
+            {
+              "name": "HP 89Y Extra High Yield Black Original LaserJet Toner Cartridge",
+              "part_number": "CF289Y",
+              "yield_pages": 20000
+            }
+          ],
+          "image": "/static/img/printers/hp-laserjet-enterprise-m507dn.svg",
+          "image_alt": "Stylized illustration of the HP LaserJet Enterprise M507dn laser printer"
+        },
+        {
+          "model": "Color LaserJet Pro M454dw",
+          "category": "Color laser printer",
+          "release_year": 2019,
+          "cartridges": [
+            {
+              "name": "HP 414A Black Original LaserJet Toner Cartridge",
+              "part_number": "W2020A",
+              "yield_pages": 2400
+            },
+            {
+              "name": "HP 414A Cyan Original LaserJet Toner Cartridge",
+              "part_number": "W2021A",
+              "yield_pages": 2100
+            },
+            {
+              "name": "HP 414A Magenta Original LaserJet Toner Cartridge",
+              "part_number": "W2023A",
+              "yield_pages": 2100
+            },
+            {
+              "name": "HP 414A Yellow Original LaserJet Toner Cartridge",
+              "part_number": "W2022A",
+              "yield_pages": 2100
+            },
+            {
+              "name": "HP 414X High Yield Black Original LaserJet Toner Cartridge",
+              "part_number": "W2020X",
+              "yield_pages": 7500
+            },
+            {
+              "name": "HP 414X High Yield Cyan Original LaserJet Toner Cartridge",
+              "part_number": "W2021X",
+              "yield_pages": 6000
+            },
+            {
+              "name": "HP 414X High Yield Magenta Original LaserJet Toner Cartridge",
+              "part_number": "W2023X",
+              "yield_pages": 6000
+            },
+            {
+              "name": "HP 414X High Yield Yellow Original LaserJet Toner Cartridge",
+              "part_number": "W2022X",
+              "yield_pages": 6000
+            }
+          ],
+          "image": "/static/img/printers/hp-color-laserjet-pro-m454dw.svg",
+          "image_alt": "Stylized illustration of the HP Color LaserJet Pro M454dw laser printer"
+        }
+      ]
+    },
+    {
+      "name": "Canon",
+      "models": [
+        {
+          "model": "imageCLASS LBP6230dw",
+          "category": "Monochrome laser printer",
+          "release_year": 2014,
+          "cartridges": [
+            {
+              "name": "Canon 126 Black Toner Cartridge",
+              "part_number": "3483B001",
+              "yield_pages": 2100
+            }
+          ],
+          "image": "/static/img/printers/canon-imageclass-lbp6230dw.svg",
+          "image_alt": "Stylized illustration of the Canon imageCLASS LBP6230dw laser printer"
+        },
+        {
+          "model": "imageCLASS MF445dw",
+          "category": "Monochrome laser multifunction",
+          "release_year": 2020,
+          "cartridges": [
+            {
+              "name": "Canon 057 Black Toner Cartridge",
+              "part_number": "3010C001",
+              "yield_pages": 3100
+            },
+            {
+              "name": "Canon 057H High Yield Black Toner Cartridge",
+              "part_number": "3010C002",
+              "yield_pages": 10000
+            }
+          ],
+          "image": "/static/img/printers/canon-imageclass-mf445dw.svg",
+          "image_alt": "Stylized illustration of the Canon imageCLASS MF445dw laser printer"
+        },
+        {
+          "model": "imageCLASS LBP226dw",
+          "category": "Monochrome laser printer",
+          "release_year": 2020,
+          "cartridges": [
+            {
+              "name": "Canon 052 Black Toner Cartridge",
+              "part_number": "2199C001",
+              "yield_pages": 3100
+            },
+            {
+              "name": "Canon 052H High Yield Black Toner Cartridge",
+              "part_number": "2200C001",
+              "yield_pages": 9200
+            }
+          ],
+          "image": "/static/img/printers/canon-imageclass-lbp226dw.svg",
+          "image_alt": "Stylized illustration of the Canon imageCLASS LBP226dw laser printer"
+        },
+        {
+          "model": "imageCLASS MF269dw II",
+          "category": "Monochrome laser multifunction",
+          "release_year": 2021,
+          "cartridges": [
+            {
+              "name": "Canon 051 Black Toner Cartridge",
+              "part_number": "2168C001",
+              "yield_pages": 1700
+            },
+            {
+              "name": "Canon 051H High Yield Black Toner Cartridge",
+              "part_number": "2169C001",
+              "yield_pages": 4100
+            }
+          ],
+          "image": "/static/img/printers/canon-imageclass-mf269dw-ii.svg",
+          "image_alt": "Stylized illustration of the Canon imageCLASS MF269dw II laser printer"
+        }
+      ]
+    },
+    {
+      "name": "Kyocera",
+      "models": [
+        {
+          "model": "ECOSYS P2040dw",
+          "category": "Monochrome laser printer",
+          "release_year": 2017,
+          "cartridges": [
+            {
+              "name": "Kyocera TK-1178 Toner Kit",
+              "part_number": "1T02S50US0",
+              "yield_pages": 7200
+            }
+          ],
+          "image": "/static/img/printers/kyocera-ecosys-p2040dw.svg",
+          "image_alt": "Stylized illustration of the Kyocera ECOSYS P2040dw laser printer"
+        },
+        {
+          "model": "ECOSYS M5526cdw",
+          "category": "Color laser multifunction",
+          "release_year": 2017,
+          "cartridges": [
+            {
+              "name": "Kyocera TK-5242K Black Toner Kit",
+              "part_number": "1T02R9CUS0",
+              "yield_pages": 4000
+            },
+            {
+              "name": "Kyocera TK-5242C Cyan Toner Kit",
+              "part_number": "1T02R9CUS1",
+              "yield_pages": 3000
+            },
+            {
+              "name": "Kyocera TK-5242M Magenta Toner Kit",
+              "part_number": "1T02R9CUS2",
+              "yield_pages": 3000
+            },
+            {
+              "name": "Kyocera TK-5242Y Yellow Toner Kit",
+              "part_number": "1T02R9CUS3",
+              "yield_pages": 3000
+            }
+          ],
+          "image": "/static/img/printers/kyocera-ecosys-m5526cdw.svg",
+          "image_alt": "Stylized illustration of the Kyocera ECOSYS M5526cdw laser printer"
+        },
+        {
+          "model": "ECOSYS P3155dn",
+          "category": "Monochrome laser printer",
+          "release_year": 2019,
+          "cartridges": [
+            {
+              "name": "Kyocera TK-3192 Toner Kit",
+              "part_number": "1T02T80US0",
+              "yield_pages": 25000
+            }
+          ],
+          "image": "/static/img/printers/kyocera-ecosys-p3155dn.svg",
+          "image_alt": "Stylized illustration of the Kyocera ECOSYS P3155dn laser printer"
+        },
+        {
+          "model": "ECOSYS P6235cdn",
+          "category": "Color laser printer",
+          "release_year": 2019,
+          "cartridges": [
+            {
+              "name": "Kyocera TK-5272K Black Toner Kit",
+              "part_number": "1T02TV0US0",
+              "yield_pages": 26000
+            },
+            {
+              "name": "Kyocera TK-5272C Cyan Toner Kit",
+              "part_number": "1T02TV0US1",
+              "yield_pages": 19000
+            },
+            {
+              "name": "Kyocera TK-5272M Magenta Toner Kit",
+              "part_number": "1T02TV0US2",
+              "yield_pages": 19000
+            },
+            {
+              "name": "Kyocera TK-5272Y Yellow Toner Kit",
+              "part_number": "1T02TV0US3",
+              "yield_pages": 19000
+            }
+          ],
+          "image": "/static/img/printers/kyocera-ecosys-p6235cdn.svg",
+          "image_alt": "Stylized illustration of the Kyocera ECOSYS P6235cdn laser printer"
+        }
+      ]
+    },
+    {
+      "name": "Toshiba",
+      "models": [
+        {
+          "model": "e-STUDIO 2515AC",
+          "category": "Color laser multifunction",
+          "release_year": 2016,
+          "cartridges": [
+            {
+              "name": "Toshiba T-FC415K Black Toner Cartridge",
+              "part_number": "6AJ00000152",
+              "yield_pages": 33800
+            },
+            {
+              "name": "Toshiba T-FC415C Cyan Toner Cartridge",
+              "part_number": "6AJ00000153",
+              "yield_pages": 28000
+            },
+            {
+              "name": "Toshiba T-FC415M Magenta Toner Cartridge",
+              "part_number": "6AJ00000154",
+              "yield_pages": 28000
+            },
+            {
+              "name": "Toshiba T-FC415Y Yellow Toner Cartridge",
+              "part_number": "6AJ00000155",
+              "yield_pages": 28000
+            }
+          ],
+          "image": "/static/img/printers/toshiba-e-studio-2515ac.svg",
+          "image_alt": "Stylized illustration of the Toshiba e-STUDIO 2515AC laser printer"
+        },
+        {
+          "model": "e-STUDIO 330AC",
+          "category": "Color laser multifunction",
+          "release_year": 2020,
+          "cartridges": [
+            {
+              "name": "Toshiba T-FC50U-K Black Toner Cartridge",
+              "part_number": "6AJ00000174",
+              "yield_pages": 17000
+            },
+            {
+              "name": "Toshiba T-FC50U-C Cyan Toner Cartridge",
+              "part_number": "6AJ00000175",
+              "yield_pages": 11500
+            },
+            {
+              "name": "Toshiba T-FC50U-M Magenta Toner Cartridge",
+              "part_number": "6AJ00000176",
+              "yield_pages": 11500
+            },
+            {
+              "name": "Toshiba T-FC50U-Y Yellow Toner Cartridge",
+              "part_number": "6AJ00000177",
+              "yield_pages": 11500
+            }
+          ],
+          "image": "/static/img/printers/toshiba-e-studio-330ac.svg",
+          "image_alt": "Stylized illustration of the Toshiba e-STUDIO 330AC laser printer"
+        },
+        {
+          "model": "e-STUDIO 409p",
+          "category": "Monochrome laser printer",
+          "release_year": 2019,
+          "cartridges": [
+            {
+              "name": "Toshiba T-FC415U Black Toner Cartridge",
+              "part_number": "6AJ00000158",
+              "yield_pages": 20000
+            }
+          ],
+          "image": "/static/img/printers/toshiba-e-studio-409p.svg",
+          "image_alt": "Stylized illustration of the Toshiba e-STUDIO 409p laser printer"
+        },
+        {
+          "model": "e-STUDIO 409s",
+          "category": "Monochrome laser multifunction",
+          "release_year": 2019,
+          "cartridges": [
+            {
+              "name": "Toshiba T-FC415U Black Toner Cartridge",
+              "part_number": "6AJ00000158",
+              "yield_pages": 20000
+            }
+          ],
+          "image": "/static/img/printers/toshiba-e-studio-409s.svg",
+          "image_alt": "Stylized illustration of the Toshiba e-STUDIO 409s laser printer"
+        }
+      ]
+    },
+    {
+      "name": "Kioxia",
+      "note": "Kioxia Corporation specializes in flash memory and solid-state storage solutions and has not released laser printers as of 2024.",
+      "models": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a storefront route and template that renders the printer inventory with inline editing, pagination, and purchase actions
- extend default content, navigation, and inventory records to include store metadata and vector image assets
- style the store experience and admin editor so the new page matches the site’s design system

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e5b6b89bd083339307dbfc11bb113e